### PR TITLE
Imitation MacOS UI Circles for codeblocks

### DIFF
--- a/docs/getting_started/scheduling_jobs.md
+++ b/docs/getting_started/scheduling_jobs.md
@@ -13,13 +13,13 @@ There are two types of interactive nodes.  Compute nodes run computations but ca
 ### Obtaining Interactive Nodes
 
 To get an interactive compute node with `<size>` GB of memory in your group partition called `<group_name>` for `<time>` hours, use:
-```
+```shell
 srun -p <group_name> --time=<time> --mem=<size>G --pty /bin/bash
 ```
 Common acceptable time formats include `hours:minutes:seconds`, `days-hours`, and `minutes`.
 
 Example:
-```
+```shell-session terminal=true
 [linj66@mox2 ~]$ srun -p stf --time=1:00:00 --mem=20G --pty /bin/bash
 [linj66@n2148 ~]$ 
 ```
@@ -27,7 +27,7 @@ Example:
 ---
 
 To get an interactive compute node with `<num_cores>` cores, use:
-```
+```shell
 srun -p <group_name> -A <group_name> --nodes=1 \
 --ntasks-per-node=<num_cores> --time=<time> \
 --mem=<size>G --pty /bin/bash
@@ -36,7 +36,7 @@ srun -p <group_name> -A <group_name> --nodes=1 \
 ---
 
 To get multiple interactive compute nodes with `<num_nodes>` as the number of nodes and `<cores_per_node>` as the number of cores, use:
-```
+```shell
 srun -p <group_name> -A <group_name> --nodes=<num_nodes> \
 --ntasks-per-node=<cores_per_node> --time=<time> \
 --mem=<size>G --pty /bin/bash
@@ -50,7 +50,7 @@ If you are using an interactive node to run a parallel application such as Pytho
 ---
 
 If your group has an interactive node, use the option `-p <group_name>-int` like so: 
-```
+```shell
 srun -p <group_name>-int -A <group_name> --time=<time> --mem=<size>G --pty /bin/bash
 ```
 
@@ -89,7 +89,7 @@ A comprehensive list of the environment variables Slurm sets for each job can be
 ### Single Node Batch Jobs
 
 Below is a slurm script template.  Submit a batch job from the `mox` login node by calling `sbatch <script_name>.slurm`.
-```shell title="<script_name>.slurm"
+```shell title="<script_name>.slurm" terminal=true
 !/bin/bash
 
 # JOB NAME
@@ -194,7 +194,7 @@ Use `srun <command>` to run commands on all allocated nodes.
 Use `scontrol show hostnames` to get the hostnames of your allocated nodes.  Once you have the hostnames, you can `ssh` to them using `ssh <hostname>` and then use them for your work (e.g. Apache Spark, Hadoop, etc.)
 
 Example:
-```
+```shell-session terminal=true
 [linj66@mox2 ~]$ salloc -N 2 -p stf -A stf --time=5 --mem=5G
 salloc: Pending job allocation 2620960
 salloc: job 2620960 queued and waiting for resources

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,6 +9,9 @@ module.exports = {
   plugins: [require.resolve('docusaurus-lunr-search')],
   onBrokenLinks: 'ignore',
   themeConfig: {
+    prism: {
+      additionalLanguages: ['shell-session']
+    },
     colorMode: {
       defaultMode: 'light', // "light" | "dark"
       disableSwitch: true, // Hides the switch in the navbar

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -17,9 +17,6 @@
   --ifm-code-font-size: 95%;
 }
 
-a {
-  color: #9259ff;
-}
 
 svg a:hover {
   text-decoration: none;
@@ -161,6 +158,9 @@ svg a:hover {
   padding-bottom: 5px;
 }
 
+.purple-link, .purple-link:hover, .navbar__link:hover {
+  color: #9259ff;
+}
 
 @media only screen and (max-width: 1260px) {
   .blank-map {

--- a/src/pageContent.js
+++ b/src/pageContent.js
@@ -82,10 +82,10 @@ export const HomePage = {
     HEADER: <h2>Need help?</h2>,
     SECTIONS: [
       <p key={0}>
-        Shoot us an <a href="mailto:help@uw.edu?subject=Hyak question">e-mail</a>, join
-        our <a href="https://uw-rcc.slack.com/">Slack</a>, or show up to our in-person
+        Shoot us an <a className="purple-link" href="mailto:help@uw.edu?subject=Hyak question">e-mail</a>, join
+        our <a className="purple-link" href="https://uw-rcc.slack.com/">Slack</a>, or show up to our in-person
         research hangouts every Tuesday from 1:30 PM to 3:00 PM at our global headquarters in
-        the <a href="https://escience.washington.edu">eScience Institute</a> at the
+        the <a className="purple-link" href="https://escience.washington.edu">eScience Institute</a> at the
         University of Washington.  We're also able to meet individually upon request.
       </p>,
       <div key={1} className="map-container">

--- a/src/pages/components/SplashCircle.jsx
+++ b/src/pages/components/SplashCircle.jsx
@@ -23,7 +23,7 @@ export default function SplashCircle(props) {
         y: props.yTransform || 0
       }} transition={{ duration: 0.2 }}
     >
-      <a href={props.linkTo} target="_blank">
+      <a className="circle-link" href={props.linkTo} target="_blank">
           <circle cx={props.cx} cy={props.cy} r={props.r} fill="#001b3d"  />
           <text x={props.cx} y={props.cy} dominantBaseline="middle" textAnchor="middle" style={{
             fill: "white",

--- a/src/theme/CodeBlock/MacOSCircle.jsx
+++ b/src/theme/CodeBlock/MacOSCircle.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export default function MacOSCircle(props) {
+  return (
+    <div style={{
+      width: '12px',
+      height: '12px',
+      marginBottom: '16px',
+      borderRadius: '50%',
+      backgroundColor: props.color,
+      marginLeft: props.margin ? '8px' : '0'
+    }} />
+  )
+}

--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -1,0 +1,271 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+import React, {useEffect, useState, useRef} from 'react';
+import clsx from 'clsx';
+import Highlight, {defaultProps} from 'prism-react-renderer';
+import copy from 'copy-text-to-clipboard';
+import rangeParser from 'parse-numeric-range';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import usePrismTheme from '@theme/hooks/usePrismTheme';
+import styles from './styles.module.css';
+import MacOSCircle from "./MacOSCircle";
+const highlightLinesRangeRegex = /{([\d,-]+)}/;
+
+const getHighlightDirectiveRegex = (
+  languages = ['js', 'jsBlock', 'jsx', 'python', 'html'],
+) => {
+  // supported types of comments
+  const comments = {
+    js: {
+      start: '\\/\\/',
+      end: '',
+    },
+    jsBlock: {
+      start: '\\/\\*',
+      end: '\\*\\/',
+    },
+    jsx: {
+      start: '\\{\\s*\\/\\*',
+      end: '\\*\\/\\s*\\}',
+    },
+    python: {
+      start: '#',
+      end: '',
+    },
+    html: {
+      start: '<!--',
+      end: '-->',
+    },
+  }; // supported directives
+
+  const directives = [
+    'highlight-next-line',
+    'highlight-start',
+    'highlight-end',
+  ].join('|'); // to be more reliable, the opening and closing comment must match
+
+  const commentPattern = languages
+    .map(
+      (lang) =>
+        `(?:${comments[lang].start}\\s*(${directives})\\s*${comments[lang].end})`,
+    )
+    .join('|'); // white space is allowed, but otherwise it should be on it's own line
+
+  return new RegExp(`^\\s*(?:${commentPattern})\\s*$`);
+}; // select comment styles based on language
+
+const highlightDirectiveRegex = (lang) => {
+  switch (lang) {
+    case 'js':
+    case 'javascript':
+    case 'ts':
+    case 'typescript':
+      return getHighlightDirectiveRegex(['js', 'jsBlock']);
+
+    case 'jsx':
+    case 'tsx':
+      return getHighlightDirectiveRegex(['js', 'jsBlock', 'jsx']);
+
+    case 'html':
+      return getHighlightDirectiveRegex(['js', 'jsBlock', 'html']);
+
+    case 'python':
+    case 'py':
+      return getHighlightDirectiveRegex(['python']);
+
+    default:
+      // all comment types
+      return getHighlightDirectiveRegex();
+  }
+};
+
+const codeBlockTitleRegex = /title=".*"/;
+export default ({children, className: languageClassName, metastring}) => {
+  const {
+    siteConfig: {
+      themeConfig: {prism = {}},
+    },
+  } = useDocusaurusContext();
+  const [showCopied, setShowCopied] = useState(false);
+  const [mounted, setMounted] = useState(false); // The Prism theme on SSR is always the default theme but the site theme
+  // can be in a different mode. React hydration doesn't update DOM styles
+  // that come from SSR. Hence force a re-render after mounting to apply the
+  // current relevant styles. There will be a flash seen of the original
+  // styles seen using this current approach but that's probably ok. Fixing
+  // the flash will require changing the theming approach and is not worth it
+  // at this point.
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  const button = useRef(null);
+  let highlightLines = [];
+  let codeBlockTitle = '';
+  let useMacOsCircles = false;
+  const prismTheme = usePrismTheme();
+
+  if (metastring && highlightLinesRangeRegex.test(metastring)) {
+    // Tested above
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const highlightLinesRange = metastring.match(highlightLinesRangeRegex)[1];
+    highlightLines = rangeParser
+      .parse(highlightLinesRange)
+      .filter((n) => n > 0);
+  }
+
+  if (metastring && codeBlockTitleRegex.test(metastring)) {
+    // Tested above
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    codeBlockTitle = metastring
+      .match(codeBlockTitleRegex)[0]
+      .split('title=')[1]
+      .replace(/"+/g, '');
+  }
+
+  if (metastring && metastring.includes('terminal=true')) {
+    useMacOsCircles = true
+  }
+
+  let language =
+    languageClassName && languageClassName.replace(/language-/, '');
+
+  if (!language && prism.defaultLanguage) {
+    language = prism.defaultLanguage;
+  } // only declaration OR directive highlight can be used for a block
+
+  let code = children.replace(/\n$/, '');
+
+  if (highlightLines.length === 0 && language !== undefined) {
+    let range = '';
+    const directiveRegex = highlightDirectiveRegex(language); // go through line by line
+
+    const lines = children.replace(/\n$/, '').split('\n');
+    let blockStart; // loop through lines
+
+    for (let index = 0; index < lines.length; ) {
+      const line = lines[index]; // adjust for 0-index
+
+      const lineNumber = index + 1;
+      const match = line.match(directiveRegex);
+
+      if (match !== null) {
+        const directive = match
+          .slice(1)
+          .reduce((final, item) => final || item, undefined);
+
+        switch (directive) {
+          case 'highlight-next-line':
+            range += `${lineNumber},`;
+            break;
+
+          case 'highlight-start':
+            blockStart = lineNumber;
+            break;
+
+          case 'highlight-end':
+            range += `${blockStart}-${lineNumber - 1},`;
+            break;
+
+          default:
+            break;
+        }
+
+        lines.splice(index, 1);
+      } else {
+        // lines without directives are unchanged
+        index += 1;
+      }
+    }
+
+    highlightLines = rangeParser.parse(range);
+    code = lines.join('\n');
+  }
+
+  const handleCopyCode = () => {
+    copy(code);
+    setShowCopied(true);
+    setTimeout(() => setShowCopied(false), 2000);
+  };
+
+  return (
+    <Highlight
+      {...defaultProps}
+      key={String(mounted)}
+      theme={prismTheme}
+      code={code} // @ts-expect-error: prism-react-renderer doesn't export Language type
+      language={language}>
+      {({className, style, tokens, getLineProps, getTokenProps}) => (
+        <>
+          {codeBlockTitle && (
+            <div style={style} className={styles.codeBlockTitle}>
+              {codeBlockTitle}
+            </div>
+          )}
+          <div className={styles.codeBlockContent}>
+            <button
+              ref={button}
+              type="button"
+              aria-label="Copy code to clipboard"
+              className={clsx(styles.copyButton, {
+                [styles.copyButtonWithTitle]: codeBlockTitle,
+              })}
+              onClick={handleCopyCode}>
+              {showCopied ? 'Copied' : 'Copy'}
+            </button>
+            <div
+              tabIndex={0}
+              className={clsx(className, styles.codeBlock, {
+                [styles.codeBlockWithTitle]: codeBlockTitle,
+              })}>
+              <div className={styles.codeBlockLines} style={style}>
+                {useMacOsCircles && (
+                  <div style={{
+                    display: 'flex'
+                  }}>
+                    <MacOSCircle color='#ff5f56' margin={false} />
+                    <MacOSCircle color='#ffbd2e' margin={true}/>
+                    <MacOSCircle color='#27c93f' margin={true}/>
+                  </div>
+                )}
+                {tokens.map((line, i) => {
+                  if (line.length === 1 && line[0].content === '') {
+                    line[0].content = '\n'; // eslint-disable-line no-param-reassign
+                  }
+
+                  const lineProps = getLineProps({
+                    line,
+                    key: i,
+                  });
+
+                  if (highlightLines.includes(i + 1)) {
+                    lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
+                  }
+
+                  return (
+                    <div key={i} {...lineProps}>
+                      {line.map((token, key) => (
+                        <span
+                          key={key}
+                          {...getTokenProps({
+                            token,
+                            key,
+                          })}
+                        />
+                      ))}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </Highlight>
+  );
+};

--- a/src/theme/CodeBlock/styles.module.css
+++ b/src/theme/CodeBlock/styles.module.css
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.codeBlockContent {
+  position: relative;
+}
+
+.codeBlockTitle {
+  border-top-left-radius: var(--ifm-global-radius);
+  border-top-right-radius: var(--ifm-global-radius);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  font-family: var(--ifm-font-family-monospace);
+  font-weight: bold;
+  padding: 0.75rem var(--ifm-pre-padding);
+  width: 100%;
+}
+
+.codeBlock {
+  overflow: auto;
+  border-radius: var(--ifm-global-radius);
+}
+
+.codeBlockWithTitle {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.copyButton {
+  background: rgba(0, 0, 0, 0.3);
+  border: none;
+  border-radius: var(--ifm-global-radius);
+  color: var(--ifm-color-white);
+  cursor: pointer;
+  opacity: 0;
+  outline: none;
+  padding: 0.4rem 0.5rem;
+  position: absolute;
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+  visibility: hidden;
+  transition: opacity 200ms ease-in-out, visibility 200ms ease-in-out,
+    bottom 200ms ease-in-out;
+}
+
+.codeBlockTitle:hover + .codeBlockContent .copyButton,
+.codeBlockContent:hover > .copyButton {
+  visibility: visible;
+  opacity: 1;
+}
+
+.codeBlockLines {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: inherit;
+  line-height: var(--ifm-pre-line-height);
+  white-space: pre;
+  float: left;
+  min-width: 100%;
+  padding: var(--ifm-pre-padding);
+}


### PR DESCRIPTION
- Added imitation MacOS UI Circles to swizzled `CodeBlock` component
 - Use `terminal=true` to add MacOS circles to code block in Markdown
- Added `shell-session` code block type to Docusaurus config 
- Fixed some CSS styles getting overridden by Bootstrap