### PR TITLE
change svg splash to scale dynamically with viewport

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -59,7 +59,7 @@ svg a:hover {
   color: black;
   font-weight: bold;
   font-size: 32px;
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .button {

--- a/src/pages/components/SplashImage.jsx
+++ b/src/pages/components/SplashImage.jsx
@@ -12,7 +12,7 @@ export default function SplashImage() {
   }
 
   return (
-    <svg width={1075} height={340} xmlns="http://www.w3.org/2000/svg">
+    <svg width="100%" height="48%" viewBox="20 0 1020 340" xmlns="http://www.w3.org/2000/svg">
       <defs>
         <radialGradient id="blue-radial">
           <stop offset="0%"  stopColor="#fff" />

--- a/src/theme/ScrollNotifier/styles.css
+++ b/src/theme/ScrollNotifier/styles.css
@@ -1,6 +1,6 @@
 .scroll-notifier {
   position: sticky;
-  top: 60px;  /* Navbar is 60px thick */
+  top: var(--ifm-navbar-height);  /* Navbar is 60px thick */
   height: 2px;
   background-color: #96BF47;
   z-index: 1;


### PR DESCRIPTION
- Changed SVG splash image to scale with viewport size rather than be a fixed width/height
- Changed scroll notifier offset to equal `--ifm-navbar-height` rather than a fixed offset
- Decreased margin size on TypingTagline