### PR TITLE
Delete vscode.md

### DIFF
--- a/docs/setup/vscode.md
+++ b/docs/setup/vscode.md
@@ -1,6 +1,0 @@
----
-id: vscode
-title: Visual Studio Code
----
-
-Using the Visual Studio Code (VSCode) ssh module you can use your local environment.


### PR DESCRIPTION
The vscode SSH plugin causes issues on the Klone login node, removing for now until container option is ready for docs.