### PR TITLE
Feature/logineula and ckpt

### DIFF
--- a/docs/account-activation.md
+++ b/docs/account-activation.md
@@ -1,17 +1,7 @@
 ---
 id: account-activation
-title: Account Activation
+title: Two-Factor Authentication
 ---
-
-Your UW Net ID has been enabled for access to the Hyak system. You must
-now subscribe to the service. After you subscribe, it may take up to an
-hour for your account to be fully provisioned.
-
-1. Go to [uwnetid.washington.edu](https://uwnetid.washington.edu/manage/)
-2. Click the "Computing Services" link on the left
-3. Click the "Hyak Server" check box in the "Inactive Services" section
-4. Click the "Subscribe >" button at the bottom of the page
-5. Read the notice and click the "Finish" button
 
 UW policy is that all services (of which HYAK is one) require 2 factor authentication (2FA) by default as a security posture.
 

--- a/docs/compute/checkpoint.md
+++ b/docs/compute/checkpoint.md
@@ -1,0 +1,4 @@
+---
+id: checkpoint
+title: Using Idle Resources
+---

--- a/docs/compute/checkpoint.md
+++ b/docs/compute/checkpoint.md
@@ -2,3 +2,38 @@
 id: checkpoint
 title: Using Idle Resources
 ---
+### Hyak's Condo Model
+The Hyak clusters operate on a condo model, the details of which are here: https://hyak.uw.edu/pricing
+
+The **first** component of this model is on-demand access to the resources your group has contributed. When you request resources from a partition, e.g. with:
+
+```shell terminal=true
+salloc --account labname --partition compute
+```
+
+You will be limited by the amount of resources your lab has contributed to that partition (in this example, `compute`).
+
+In other words, if your group has contributed 40 CPUs to the `compute` partition, your group will only be able to allocate 40 CPUs at any given time.
+
+### The Checkpoint Partition
+The **second** component of our condo model—and one of the major advantages of contributing to the cluster—is the "checkpoint" partition, `ckpt`. When you request resources from `ckpt`, e.g. with:
+
+```shell terminal=true
+salloc --account labname --partition ckpt
+```
+
+You can request resources from the entire cluster's idle resources (including GPUs, regardless of whether your lab has contributed any). You can view currently idle resources, both for your lab's partition and for the whole cluster, using our `hyakalloc` command ([further documentation here](https://hyak.uw.edu/docs/compute/resource-monitoring#hyakalloc)).
+
+:::tip What is an "Idle" resource?
+When we say a resource is "currently idle," that only means no running jobs are using it at this moment. "Idle" does **not** imply that you are guaranteed to receive a resource if you request it! Our job scheduler, Slurm, may already have a plan for that resource (by the lab who contributed it, or even by another checkpoint user). In other words, "currently idle" doesn't mean "idle in 5 minutes from now".
+:::
+
+### Checkpoint Limitations
+
+Jobs submitted to checkpoint are limited in the following important ways:
+
+1. All checkpoint jobs are stopped & requeued every 4 hours.
+1. All checkpoint jobs can be stopped & requeued at any time—*without notice*—if a resource contributor requests their resource (this is the mechanism which provides on-demand access to contributed resources).
+
+Hence the name "checkpoint": all jobs submitted to this partition should be designed to save their progress at regular intervals, or "checkpoints."
+

--- a/docs/compute/checkpoint.md
+++ b/docs/compute/checkpoint.md
@@ -35,5 +35,7 @@ Jobs submitted to checkpoint are limited in the following important ways:
 1. All checkpoint jobs are stopped & requeued every 4 hours.
 1. All checkpoint jobs can be stopped & requeued at any time—*without notice*—if a resource contributor requests their resource (this is the mechanism which provides on-demand access to contributed resources).
 
-Hence the name "checkpoint": all jobs submitted to this partition should be designed to save their progress at regular intervals, or "checkpoints."
+Jobs submitted to this partition should be designed to:
 
+1. Save their progress at regular intervals, or "checkpoints."
+2. Once resumed, start their work from the last saved "checkpoint."

--- a/docs/setup/intracluster-keys.md
+++ b/docs/setup/intracluster-keys.md
@@ -1,0 +1,25 @@
+---
+id: intracluster-keys
+title: Intracluster SSH Keys
+---
+
+### Creating intracluster keys
+
+Once you're logged into the login node (i.e., `klone-login01` or `klone.hyak.uw.edu`) you'll use this as a host to submit jobs, transfer data, or navigate your environment. However, you may find yourself needing to either submit multi-node (i.e., MPI) jobs or log into a node after you have a job running there to check its progress. For this you need SSH keys set up for intra cluster access. You can generate an SSH key from the login node using the command below.
+
+```
+ssh-keygen -C klone -t rsa -b 2048 -f ~/.ssh/id_rsa -q -N ""
+```
+
+This command creates a 2048-bit RSA key with "klone" in the comment field.
+
+### Authorizing the keys
+
+You will also need to add the contents of your public key to the `authorized_keys` file in your home directory with the follow commands:
+
+```
+cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+```
+
+This also also ensures the `authorized_keys` file has appropriate permissions.

--- a/docs/setup/ssh.md
+++ b/docs/setup/ssh.md
@@ -1,6 +1,6 @@
 ---
 id: ssh
-title: SSH
+title: SSH & Login Node Usage
 ---
 
 The most common method of logging into the cluster is using the command-line interface (CLI). If you're using any Linux or Linux-like system (e.g., MacOS, BSD) you probably already have a terminal installed by default. Newer versions of Windows also have a new Linux sub-system so there are also native options to bring up a local terminal.
@@ -8,24 +8,30 @@ The most common method of logging into the cluster is using the command-line int
 ### Logging into KLONE
 
 ```
-ssh netID@klone.hyak.uw.edu
+ssh UWNetID@klone.hyak.uw.edu
 ```
 
 You log into the `klone.hyak.uw.edu` cluster above at the terminal using your netID. You will be prompted for your password and 2FA (DUO) authentication. We don't allow ssh keys to the login node since it would be bypassing one of the factors (of 2-factor authentication).
 
-### Intracluster SSH Keys
+:::warning Monitoring & Warnings
 
-Once you're logged into the login node (e.g., `klone-login01` or `klone-login02`) you'll use this as a host to submit jobs, transfer data, or navigate your environment. However, you may find yourself needing to either submit multi-node (i.e., MPI) jobs or log into a node after you have a job running there to check its progress. For this you need SSH keys set up for intra cluster access. You can generate an SSH key from the login node using the command below.
+Login-node CPU and memory usage are closely monitored by automation. Any egregious use will result in immediate performance throttling, the severity of which escalates exponentially while the offending activity persists. You will receive warnings in your UW email from the monitoring system, *Arbiter2*, describing the crossed thresholds & the extent of the throttling.
+:::
 
-```
-ssh-keygen -C klone -t rsa -b 2048 -f ~/.ssh/id_rsa -q -N ""
-```
+### Acceptable Uses of the Login Node
 
-The command creates a 2048-bit RSA key with "klone" in the comment field. You'll want to also add it to your `authorized_keys` file using the command below.
+The Klone login node (i.e. `klone-login01` or `klone.hyak.uw.edu`) is a resource shared by all cluster users. As such, acceptable uses of this system are very limited:
 
-```
-cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-chmod 600 ~/.ssh/authorized_keys
-```
+1. Downloading to or uploading from the cluster.
+1. File management like moving, copying, or renaming files and directories.
+1. Light text editing with `vim` or a worse text editor.
+1. Interacting with the Slurm scheduler, i.e. to submit jobs.
+2. Running Hyak-built commands like `hyakalloc` or `hyakstorage`.
 
-It also ensures the file has appropriate permissions.
+
+
+:::tip
+
+If your command would run a little slow on an inexpensive laptop from 2002, you shouldn't run it on the login node! Instead, request an [interactive job](https://hyak.uw.edu/docs/compute/scheduling-jobs#interactive-jobs-single-node) on a compute node.
+
+:::

--- a/docs/setup/ssh.md
+++ b/docs/setup/ssh.md
@@ -26,7 +26,7 @@ The Klone login node (i.e. `klone-login01` or `klone.hyak.uw.edu`) is a resource
 1. File management like moving, copying, or renaming files and directories.
 1. Light text editing with `vim` or a worse text editor.
 1. Interacting with the Slurm scheduler, i.e. to submit jobs.
-2. Running Hyak-built commands like `hyakalloc` or `hyakstorage`.
+1. Running Hyak-built commands like `hyakalloc` or `hyakstorage`.
 
 
 

--- a/docs/setup/ssh.md
+++ b/docs/setup/ssh.md
@@ -15,7 +15,7 @@ You log into the `klone.hyak.uw.edu` cluster above at the terminal using your ne
 
 :::warning Monitoring & Warnings
 
-Login-node CPU and memory usage are closely monitored by automation. Any egregious use will result in immediate performance throttling, the severity of which escalates exponentially while the offending activity persists. You will receive warnings in your UW email from the monitoring system, *Arbiter2*, describing the crossed thresholds & the extent of the throttling.
+Login-node CPU and memory usage are closely monitored by automation. Any egregious use will result in immediate performance throttling, the severity of which escalates exponentially while the offending activity persists. Warnings describing the crossed thresholds & the extent of the throttling will be sent by our monitoring system, *Arbiter2*, to the email associated with your UW NetID.
 :::
 
 ### Acceptable Uses of the Login Node

--- a/sidebars.js
+++ b/sidebars.js
@@ -9,6 +9,7 @@ module.exports = {
     'Setup': [
       'setup/index',
       'setup/ssh',
+      'setup/intracluster-keys',
       'setup/portforwarding',
       'setup/x11'
       //'setup/vscode',
@@ -22,6 +23,7 @@ module.exports = {
     'Compute': [
       'compute/slurm',
       'compute/scheduling-jobs',
+      'compute/checkpoint',
       'compute/resource-monitoring',
     ],
     'Tools & Software': [


### PR DESCRIPTION
Made the following changes:

1. Removed the Mox account activation instructions.
2. Added a page explaining checkpoint.
3. Moved intracluster keys to its own page, so that:
4. The first mention of SSHing to the login node includes **Acceptable Uses of the Login Node**.