### PR TITLE
Fixing wrong command in "A short script to get the node hostname" sec…

### DIFF
--- a/docs/hyak101/python/overlay.md
+++ b/docs/hyak101/python/overlay.md
@@ -114,7 +114,7 @@ You can download the script [here](https://hyak.uw.edu/files/hyak101/python/set-
 
 ```bash title="~/set-hyak-node.sh"
 #!/bin/bash
-NODE=$(ssh klone 'squeue \
+NODE=$(ssh klone-login 'squeue \
     --user $USER \
     --states RUNNING \
     --name klone-container \


### PR DESCRIPTION
…tion script

The script to download or copy should begin with ssh klone-login instead of ssh klone