### PR TITLE
Misspelled words in SDSC training blog post

### DIFF
--- a/blog/2024-03-08-SDSC-training.md
+++ b/blog/2024-03-08-SDSC-training.md
@@ -10,7 +10,7 @@ tags: [hpc,cl,datascience,training,sdsc,opportunity,application]
 
 Hello HYAK Community! 
 
-We wanted to make you aware of two training opportunities with the San Diego Supercomputer Center (SDSC). If you are intersted in picking up some additional skills and expereince in HPC, please check them out.
+We wanted to make you aware of two training opportunities with the San Diego Supercomputer Center (SDSC). If you are interested in picking up some additional skills and experience in HPC, please check them out.
 
 * **SDSC Cyberinfrastructure-Enabled Machine Learning (CIML) Summer Institute**: The project is focused on teaching researchers and students the best practices for effectively running machine learning (ML) and data science applications on advanced cyberinfrastructure (CI) and high-performance computing (HPC) systems. Applications due 12 April 2024. https://www.sdsc.edu/education_and_training/ciml_summer_institute.html 
 


### PR DESCRIPTION
Correcting two misspelled words in the blog post about SDSC training. Face palm.