### PR TITLE
Instructions for ProxyJump for Windows users

### DIFF
--- a/blog/2024-03-08-SDSC-training.md
+++ b/blog/2024-03-08-SDSC-training.md
@@ -10,7 +10,7 @@ tags: [hpc,cl,datascience,training,sdsc,opportunity,application]
 
 Hello HYAK Community! 
 
-We wanted to make you aware of two training opportunities with the San Diego Supercomputer Center (SDSC). If you are intersted in picking up some additional skills and expereince in HPC, please check them out.
+We wanted to make you aware of two training opportunities with the San Diego Supercomputer Center (SDSC). If you are interested in picking up some additional skills and experience in HPC, please check them out.
 
 * **SDSC Cyberinfrastructure-Enabled Machine Learning (CIML) Summer Institute**: The project is focused on teaching researchers and students the best practices for effectively running machine learning (ML) and data science applications on advanced cyberinfrastructure (CI) and high-performance computing (HPC) systems. Applications due 12 April 2024. https://www.sdsc.edu/education_and_training/ciml_summer_institute.html 
 

--- a/docs/hyak101/python/ssh.md
+++ b/docs/hyak101/python/ssh.md
@@ -3,12 +3,8 @@ id: ssh
 title: Flexible Connections
 ---
 
-:::note A note for Windows users:
-
-Currently, these instructions only apply to MacOS and Linux. We are working
-on a set of Windows instructions, and will send an announcement via the hyak-users mailing list
-when they're complete.
-
+:::note
+As a rule, we prohibit users running processes on the login node. A ProxyJump is a useful solution that can help you link external software to the server for real time code development. 
 :::
 
 ## Spending some time on SSH
@@ -41,13 +37,16 @@ $ chmod 600 ~/.ssh/authorized_keys
 ## A set of customized, local configurations
 :::important
 
-This entire next section is done on your local computer—your personal MacOS or Linux machine—**not** on the cluster.
+This entire next section is done on your local computer—your personal MacOS/Linux or Windows machine—**not** on the cluster.
 
 :::
 
 ### Your primary SSH config
 
-First up is our main SSH configuration file, located at `~/.ssh/config`.
+First up is our main SSH configuration file, located at `~/.ssh/config`. The contents of your SSH configuration file will depend on the operating system of your local machine (Mac/Linux or Windows). 
+
+#### Mac/Linux Users
+
 You can use the following template, making sure to change out `UWNetID` for your UW Net ID that you use to log in:
 
 ```shell title="~/.ssh/config"
@@ -82,16 +81,34 @@ Here's a quick rundown of the options we're setting:
 - `ServerAliveCountMax 1200`: don't close the connection unless we've sent 1200 server-alive messages
 without a response from the login node.
 - `ControlMaster auto`: enable SSH multiplexing, i.e. connection sharing. This means once we've established the first connection,
-we won't have to reauthenticate for subsequent connections: the new connection will just use the already open socket.
+we won't have to reauthenticate for subsequent connections: the new connection will just use the already open socket. This feature is no supported for Windows Users.
 - `ControlPersist 3600`: this keeps the control socket open for an hour after the initial connection has been closed.
 - `ControlPath ~/.ssh/%r@klone-login:%p`: this is the path where the socket, appearing as a file, will actually be located. The `%r` is
 an abbreviation for the remote username, i.e. your UW Net ID, and `%p` is an abbreviation for the port (normally 22 for SSH).
 
-Finally, the last line will include the next file we're going to make: an additional configuration for our job node.
+Finally, the last line will include the next file we're going to make: A secondary config for the node.
+
+#### Windows Users
+
+You can use the following template, making sure to change out `UWNetID` for your UW Net ID that you use to log in:
+
+```shell title="~/.ssh/config"
+Host klone-login
+//highlight-next-line
+        User UWNetID
+        Hostname klone.hyak.uw.edu
+        ServerAliveInterval 30
+        ServerAliveCountMax 1200
+
+Host klone-node
+    Include klone-node-config
+```
 
 ### A secondary config for the node
 
-This is a short one: we're defining `klone-node` as a compute node (`n3000`, until we know what the node will be), and
+These instructions are the same for Windows and Mac/Linux users. 
+
+Here we're defining `klone-node` as a compute node (`n3000`, until we know what the node will be), and
 using `ProxyJump` to connect to that node through the login node.
 
 ```shell title="~/.ssh/klone-node-config"
@@ -101,23 +118,59 @@ Host klone-node
   ProxyJump klone-login
 ```
 
-This file will also need the correct permissions:
+This file will also need the correct permissions. **Windows should not require a permissions check.** Mac/Linux update permissions with:
 
 ```shell terminal=true
 $ chmod 600 ~/.ssh/klone-node-config
 ```
 
-We need to copy our local ssh key onto klone. While we cannot use our key as a authentication factor between our local machine and klone, we can use it when ssh'ing *between* klone nodes.
+Because you will be effectively connecting directly from your local computer to the node, you will need to append the SSH public key from your **local** system to the `.ssh/authorized_keys` file under your cluster home directory on klone. Or you can do the same by copying your local ssh key onto klone. While we cannot use our key as a authentication factor between our local machine and klone, we can use it when ssh'ing *between* klone nodes.
 
 ```shell terminal=true
 $ ssh-copy-id klone-login
 ```
 
-Once we've requested a job, and we know what node its on, we'll swap out the `Hostname` line &
-connecting directly to the node will be this simple:
+#### Windows Users
+
+If your private key permissions are too open, ssh won't let you connect to klone. To solve this, change the permissions on your private key file. [Apply this solution.](https://superuser.com/questions/1296024/windows-ssh-permissions-for-private-key-are-too-open)
+
+### Testing your connection
+
+:::note
+
+You will test the connection in the next section of the Hyak 101 tutorial. If you wish to test your connection now, follow these steps.  
+
+:::
+
+First, test your new `ssh` shortcut to get onto the login node.
+Then, request an interactive job in the `ckpt` partition with 1 CPU (unless otherwise specified with `--ntasks`, a job will have 1 task) and 16GB of memory:
+
+```shell terminal=true
+$ ssh klone-login
+$ salloc --partition=ckpt --cpus-per-task=1 --mem=16G --job-name=testing
+```
+
+The `Hostname` will appear when your node is allocated, and follow your UWNetID For example:
+
+```shell terminal=true
+$ salloc: Nodes n3319 are ready for job
+[UWNetID@n3319 ~]$
+```
+
+The next section of the tutorial will introduce a script that when run on locally will replace the `Hostname` line of your `~/.ssh/klone-node-config` file. For now, manually replace the `Hostname` line with your job node. 
+
+```shell title="~/.ssh/klone-node-config"
+Host klone-node
+  User UWNetID
+//highlight-next-line
+  Hostname n3319
+  ProxyJump klone-login
+```
+
+Test your shortcut to connect directly to the node from your local computer:
 
 ```shell terminal=true
 $ ssh klone-node
+. . .
+[UWNetID@n3319 ~]$
 ```
-
-Because you are effectively connecting directly from your local computer to the node, you will need to append the SSH public key from your **local** system to the `.ssh/authorized_keys` file under your cluster home directory.


### PR DESCRIPTION
Since we might be encouraging users to connect directly to compute nodes during the March maintenance email or in a blog post, I wanted to add instructions for ProxyJump for Windows users, which was not supported before. 
Steps included: 

- Indicate that instructions are for Mac/Linux and Windows.
- Distinguish .config files for Mac/Linux vs. Windows.
- Connect tidbits about public keys, which were disjointed. 
- Section added for testing your connection BEFORE moving on to the next section of the tutorial. I made this decision because we know that folks will use bits and pieces of the tutorial to accomplish their task. This allows them to more quickly test the connection if they only care about the Proxy jump (e.g., if they want to connect VS Code to klone). Before this change, testing the connection comes after building the container overlay, which in my opinion is too disjointed from the proxy jump and difficult to find. 

This is only a temporary fix, but I think it will help many users and hopefully help users preserve login node for community usage.  