### PR TITLE
Information about demo accounts added

### DIFF
--- a/docs/account-creation.md
+++ b/docs/account-creation.md
@@ -5,22 +5,34 @@ title: Account Creation
 
 To log into any HYAK cluster you need an account created. Everyone falls into one of the following buckets. Follow through then once your sponsor has confirmed they've added you to their group, continue on to the next section to complete the final account activation.
 
-## I have a PI and the PI contributed HYAK nodes.
+### I am a PI, but I'm not ready to purchase a slice yet.
+
+The demo or free-tier accounts are intended for prospective slice owners to use the HYAK resources and assess whether the resources can serve their research computing needs. The account has some limits and not all features of HYAK will be available for demonstration, but you will be able to test workflows and software on the cluster. <a href="mailto:help@uw.edu?subject=hyak free tier account">Email us</a> to open a demo account. [Please note the limitations of HYAK demo accounts listed below.](https://hyak.uw.edu/docs/account-creation#limitations-of-demo-accounts)
+
+### I have a PI and the PI contributed HYAK nodes.
 
 Your PI can create a HYAK account for you by virtue of adding you to their group. Refer to the previous section about [adding users to a group](/docs/join-group).
 
-## I have a PI and we have no HYAK nodes.
+### I have a PI and we have no HYAK nodes.
 
-You need to <a href="mailto:help@uw.edu?subject=hyak free tier account">email us</a> to get a free tier account. Please provide your UW netID.
+<a href="mailto:help@uw.edu?subject=hyak free tier account">Email us</a> to open a demo or free tier account. Please provide your UW netID. <a href="https://hyak.uw.edu/docs/account-creation#limitations-of-demo-accounts">Please note the limitations of HYAK demo accounts listed below</a>. If your PI has purchased HYAK storage you will need them to follow the step above to be <a href="https://hyak.uw.edu/docs/join-group">added to the group</a> to gain access to your shared data storage on the cluster after you're able to log in.
 
-If your PI has purchased HYAK storage you will need them to follow the step above to be added to the group and have access to your shared data on the cluster after you're able to log in.
-
-## I'm a UW student and I have no PI.
+### I'm a UW student and I have no PI.
 
 If you are a UW student tech fee (STF) paying student, which is almost every UW student, you are eligible to join the Research Computing Club (RCC). The RCC has a pool of nodes on every HYAK cluster for you to use. You can join the RCC and thereby get a Hyak account created through them [here](https://depts.washington.edu/uwrcc/getting-started-2/getting-started/) and use their resource capacity on the cluster. Once your account is created you can resume to the next page with instructions on how to activate.
 
-## I am an external collaborator or I have no UW netID.
+### I am an external collaborator or I have no UW netID.
 
 Having a UW netID is a pre-requisite for any type of HYAK account creation. If you are an external collaborator of a current HYAK user and need a UW netID you will need to have your UW collaborator sponsor you for a netID.
 
 Please have them follow [these](https://itconnect.uw.edu/security/uw-netids/about-uw-netids/about-sponsored-uw-netids/) instructions then once you have your netID, find yourself in one of the previous categories to be added to a group. Once you are added to a group you can resume with account activation on the next page.
+
+### Limitations of Demo Accounts
+
+Demonstration accounts are subject to the following restrictions:
+* Jobs may only be submitted to the <a href="https://hyak.uw.edu/docs/compute/checkpoint#the-checkpoint-partition">ckpt partition</a>.
+* Storage is limited under the demo account to <a href="https://hyak.uw.edu/docs/storage/gscratch#user-home-directory">10GB in the home directory</a>. For additional temporary storage you may utilize <a href="https://hyak.uw.edu/docs/storage/gscratch#scrubbed"> /gscratch/scrubbed storage</a>. Be aware that files in scrubbed not used for several months will be deleted. This storage in not intended for large datasets, but can be helpful as you try out workflows on HYAK.
+* You may submit as many jobs as you like, but the scheduler will only allow one to run at a time.
+* Your jobs are limited to 80 cores, 360 GB of memory, 2 GPUs, and a maximum of 2 discrete nodes.
+
+If you intend to purchase slices and are unable to test your workflows to your satisfaction, <a href="mailto:help@uw.edu?subject=hyak support">please open a support ticket</a> explaining the features you would like to test before purchasing slices, and we will find a way to accomedate you. 

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -20,6 +20,7 @@ export default function Pricing() {
         {label: 'Compute', value: 'compute'},
         {label: 'Storage', value: 'storage'},
         {label: 'Support', value: 'support'},
+        {label: 'Try HYAK for Free', value: 'trial'},
       ]}>
       <TabItem value="compute">
         <div class="row">
@@ -294,7 +295,25 @@ id=sc_cat_item&sys_id=d307c0cadb5e73c037ae9ec6db961963">
       </TabItem>
 
       <TabItem value="support">
-        All storage and compute purchases come with support. A team of systems and storage engineers as well as staff scientists will provide at least next business day acknowledgement of any emails or tickets. Depending on the nature of the request or question there may be further delayed follow up for the tasks at hand. To start a help ticket email help@uw.edu and include HYAK in the subject line. Or use the "Email" link below.
+      <p>All storage and compute purchases come with support. A team of systems and storage engineers as well as staff scientists will provide at least next business day acknowledgement of any emails or tickets. Depending on the nature of the request or question there may be further delayed follow up for the tasks at hand. To start a help ticket email help@uw.edu and include HYAK in the subject line. Or use the button below.</p>
+        
+        <a href="mailto:help@uw.edu?subject=hyak support&body=Please direct this message to the HYAK team.">
+            <button class="button button--secondary button--block">Request Support</button></a>
+      </TabItem>
+
+      <TabItem value="trial">
+      <h3>HYAK Demo Accounts</h3>
+            <p>The demo or free-tier accounts are intended for prospective slice owners to use the HYAK resources and assess whether the resources can serve their research computing needs. The account has some limits and not all features of HYAK will be available for demonstration, but you will be able to test workflows and software on the cluster.</p>  
+            <b>Demonstration accounts are subject to the following restrictions</b>:
+            <ul>
+              <li>Jobs may only be submitted to the <a href="https://hyak.uw.edu/docs/compute/checkpoint#the-checkpoint-partition">ckpt partition</a>.</li>
+              <li>Storage is limited under the demo account to <a href="https://hyak.uw.edu/docs/storage/gscratch#user-home-directory">10GB in the home directory</a>. For additional temporary storage you may utilize <a href="https://hyak.uw.edu/docs/storage/gscratch#scrubbed"> /gscratch/scrubbed storage</a>. Be aware that files in scrubbed not used for several months will be deleted. This storage in not intended for large datasets, but can be helpful as you try out workflows on HYAK.</li>
+              <li>You may submit as many jobs as you like, but the scheduler will only allow one to run at a time.</li>
+              <li>Your jobs are limited to 80 cores, 360 GB of memory, 2 GPUs, and a maximum of 2 discrete nodes.</li>
+            </ul>
+            <a href="mailto:help@uw.edu?subject=hyak demo account&body=I would like to open a HYAK demo account.">
+            <button class="button button--secondary button--block">Request a HYAK Demo Account</button></a>
+          
       </TabItem>
     </Tabs>
 


### PR DESCRIPTION
In an attempt to better set expectations and intentions for demo accounts, I:

- added a tab to the pricing page for "Try HYAK for Free"
- the "Try HYAK for Free" includes the limitations of demo accounts (from boilerplates.md) and a button to request a demo account
- I also added a button for "Request Support" under the Support tab
- Under the documentation/account creation page, I added a section for PI's who are not ready to purchase slices yet. 
- To the bottom of the accounts page, I also added the limitations of demo accounts since you can't link directly to the "Try HYAK for Free" page.