### PR TITLE
Update vsc-proxy-jump script so that it will not make an invalid ssh config

### DIFF
--- a/docs/tools/vsc-proxy-jump.md
+++ b/docs/tools/vsc-proxy-jump.md
@@ -160,6 +160,7 @@ Manually editing `~/.ssh/klone-node-config` everytime you want to connect VS Cod
 
 ```bash title="set-hyak-node.sh"
 #!/bin/bash
+set -euo pipefail
 NODE=$(ssh klone-login 'squeue \
     --user $USER \
     --states RUNNING \


### PR DESCRIPTION
Currently, the suggested script for pulling the node with an interactive job from Hyak will make an invalid local ssh config by leaving an empty hostname if there is no node with an interactive job of the right name. 

This change proposes the script fails before making an invalid config using `set -euo pipefail`. 

