### PR TITLE
VS Code instruction edits

### DIFF
--- a/docs/tools/vsc-code-server.md
+++ b/docs/tools/vsc-code-server.md
@@ -78,13 +78,13 @@ Submit the script with `sbatch`. **Repeat this step and all following steps each
 ```bash
 //highlight-next-line
 sbatch code-server.job
-Submitted batch job 17440706
+Submitted batch job 12345678
 ```
-This script will start a batch job and launch the code-server container. The `SSH` tunneling instructions, including the code-server session password, will be written to the output file (`stdout`) called `code-server.job.<JobID>` (`code-server.job.17440706` in this example). Concatenate (`cat`) the output file for tunneling instructions. The following is an example output.
+This script will start a batch job and launch the code-server container. The `SSH` tunneling instructions, including the code-server session password, will be written to the output file (`stdout`), for example `code-server.job.12345678` would be the output file in here where 12345678 is our fictional Job ID--the JobID for your output file will be different. Concatenate (`cat`) the output file for tunneling instructions. The following is an example output.
 
 ```bash
 //highlight-next-line
-cat code-server.job.17440706
+cat code-server.job.12345678
 1. SSH tunnel from your workstation using the following command:
 
    ssh -N -L 8080:n3088:59985 UWNetID@klone.hyak.uw.edu
@@ -100,7 +100,7 @@ When done using Code Server, terminate the job by:
 1. Sign out of Code Server (Find the three-lines icon Menu and select "Sign out of Code Server")
 2. Issue the following command on the login node:
 
-      scancel --name code-server
+      scancel -f 12345678
 ```
 
 :::tip Pro Tip
@@ -110,11 +110,11 @@ Monitor the job with `squeue` and your UWNetID like the following example.
 //highlight-next-line
 squeue -u <UWNetID>
              JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
-          17440706   compute code-ser  UWNetID  R       3:15      1 n3088
+          12345678   compute code-ser  UWNetID  R       3:15      1 n3088
 ```
 :::
 
-The output file (`code-server.job.17440706` in this example) will also contain messages from `code-server` as the connection is established. These messages include:
+The output file (`code-server.job.12345678` in this example) will also contain messages from `code-server` as the connection is established. These messages include:
 
 1. The storage location of session associated files - `~/.local/share/code-server` in your home directory.
 2. The location of the configuration file for the session which contains the password that is also printed in the output file - `~/.config/code-server/config.yaml` in your home directory.
@@ -124,7 +124,7 @@ As your session continues, more information will be printed to this output file.
 
 ### Establish the SSH tunnel
 
-Follow the instructions in the output file. Open a new terminal/powershell/PuTTy window **ON YOUR COMPUTER** and use your version of the tunnel command from your job output file (e.g., `code-server.job.17440706`). The following is an example:
+Follow the instructions in the output file. Open a new terminal/powershell/PuTTy window **ON YOUR COMPUTER** and use your version of the tunnel command from your job output file (e.g., `code-server.job.12345678`). The following is an example:
 ```bash
 //highlight-next-line
 ssh -N -L 8080:n3088:59985 UWNetID@klone.hyak.uw.edu
@@ -149,10 +149,10 @@ To end your session, find the three-lines icon Menu and select "Sign out of Code
 
 ![](/img/docs/vscode/vsc-signout.png 'Sign Out')
 
-And end the batch job with `scancel` on `klone` like the following example.
+And end the batch job with `scancel` and the JobID on `klone` like the following example.
 
 ```bash
-scancel --name code-server
+scancel -f 12345678
 ```
 
 If you have trouble with this method, please report errors in an email to **help@uw.edu** with HYAK in the message. 

--- a/docs/tools/vsc-proxy-jump.md
+++ b/docs/tools/vsc-proxy-jump.md
@@ -158,6 +158,8 @@ We will use this short cut (ProxyJump) with the `Remote-SSH` extension of VS Cod
 :::tip PRO TIP
 Manually editing `~/.ssh/klone-node-config` everytime you want to connect VS Code is tedious and prone to error. Use the following bash script **ON YOUR COMPUTER** to get the hostname of the compute node you wish to connect to with your ProxyJump. [**Download the script here**](https://hyak.uw.edu/files/set-hyak-node.sh).
 
+**WARNING this script doesn'tusually work on Windows since bash and sed are not available. AND it might not work if you have a different version of sed**
+
 ```bash title="set-hyak-node.sh"
 #!/bin/bash
 set -euo pipefail

--- a/static/files/code-server.job
+++ b/static/files/code-server.job
@@ -49,7 +49,7 @@ When done using Code Server, terminate the job by:
 1. Signing out of Code Server (Find the lines icon Menu and select "Sign out of Code Server")
 2. Issue the following command on the login node:
 
-      scancel --name ${SLURM_JOB_NAME}
+      scancel -f ${SLURM_JOB_ID}
 END
 
 source /etc/bashrc


### PR DESCRIPTION
I made minor fixes to VS Code instructions based on user feedback. 
- scancel with --name doesn't always work. Fixed. 
- stipulations added to ProxyJump that short cuts might only work for Mac/Linux users.