### PR TITLE
Bottom banner update. 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -121,8 +121,8 @@ module.exports = {
               href: 'https://environment.uw.edu',
             },
             {
-              label: 'Institute for Protein Design',
-              href: 'https://www.ipd.uw.edu',
+              label: 'School of Medicine',
+              href: 'https://www.uwmedicine.org/school-of-medicine',
             },
           ],
         },


### PR DESCRIPTION
I updated the bottom banner on the website to show SoM as a sponsor and removed Institute of Protein design since they are SoM. This was a suggestion from Daniel Bascom. 