### PR TITLE
Update kopah docs

### DIFF
--- a/docs/storage/cli.md
+++ b/docs/storage/cli.md
@@ -58,6 +58,11 @@ The following are a small collection of the many commands available with S3cmd.
 |`s3cmd put FILE [FILE...] s3://BUCKET[/PREFIX]`|Put a file into the bucket|
 |`s3cmd put --acl-public FILE [FILE...] s3://BUCKET[/PREFIX]`|Put a file into a bucket and make it public|
 |`s3cmd get s3://BUCKET/OBJECT LOCAL_FILE`|Get a file from the bucket|
+|`s3cmd setacl --acl-private s3://BUCKET/OBJECT`|Make an object in the bucket private.|
+
+:::caution
+Buckets and objects shouldn't be public unless necessary, set them private whenever possible!
+:::
 
 ### S3cmd usage on `klone`
 

--- a/docs/storage/cli.md
+++ b/docs/storage/cli.md
@@ -3,7 +3,11 @@ id: cli
 title: S3 CLIs
 ---
 
-On this page we will provide options to interact with your S3 data on KOPAH via Command Line Interfaces (CLIs).
+On this page we detail two options data on KOPAH via Command Line Interfaces (CLIs). s3cmd is a popular and widely used tool, while s5cmd is faster but less widely used.
+
+note:::
+These tools aren't the only ones compatible with KOPAH, however you will need to set them up to work with Ceph, KOPAH's underlying storage protocol.
+:::
 
 ## S3cmd
 
@@ -75,3 +79,28 @@ nano .s3cfg
 ```
 Prepare your `.s3cfg` file as shown above. 
 
+## S5cmd
+
+[**s5cmd**](https://github.com/peak/s5cmd) is an open-source tool for transferring and managing data with S3-API compatible storage. It is less widely used than s3cmd, however data transfer is much quicker.
+
+### Setup
+
+s5cmd is pre-installed on KLONE. To install locally, view the [**developer's instructions**](https://github.com/peak/s5cmd#installation).
+
+s3cmd must be configured to interact with KOPAH. To do so, set the following environment variables in your shell.
+
+:::note
+These commands should likely be added in your `~/.bashrc` file, so they are automatically run on each terminal session. The commands in your `~/.bashrc` file will automatically run on any new shell session, however you need to source it (`source ~/.bashrc`) to make the variables accessible in your current session.
+:::
+
+```bash
+export AWS_ACCESS_KEY_ID='<KOPAH ACCESS KEY>'     # replace with KOPAH access key
+export AWS_SECRET_ACCESS_KEY='<KOPAH SECRET KEY>' # replace with KOPAH secret key
+export S3_ENDPOINT_URL='https://s3.kopah.orci.washington.edu'
+```
+
+To test the setup, run `s5cmd ls` to list your existing buckets. If that succeeds, s5cmd is ready for use!
+
+### Usage
+
+Run `s5cmd -h` for information on how to use s5cmd or see the [**developer examples**](https://github.com/peak/s5cmd).

--- a/docs/storage/cli.md
+++ b/docs/storage/cli.md
@@ -94,7 +94,7 @@ s5cmd is not installed on KLONE by default. To install s5cmd:
 5. Delete the original archive: `rm s5cmd_2.2.2_Linux-64bit.tar.gz`
 
 :::note
-Installing s5cmd locally will likely be similar, make sure to consult their [installation documentation](s5cmd_2.2.2_Linux-64bit.tar.gz).
+Installing s5cmd locally will likely be similar, make sure to consult their [**installation documentation**](s5cmd_2.2.2_Linux-64bit.tar.gz).
 :::
 
 s3cmd must be configured to interact with KOPAH. To do so, set the following environment variables in your shell.

--- a/docs/storage/cli.md
+++ b/docs/storage/cli.md
@@ -9,17 +9,17 @@ note:::
 These tools aren't the only ones compatible with KOPAH, however you will need to set them up to work with Ceph, KOPAH's underlying storage protocol.
 :::
 
-## S3cmd
+## s3cmd
 
-S3cmd is a free command line tool and client for uploading, retrieving and managing data in KOPAH. It is best suited for power users who are familiar with command line programs. It is also ideal for batch scripts and if automated backup to KOPAH is desired.
+s3cmd is a free command line tool and client for uploading, retrieving and managing data in KOPAH. It is best suited for power users who are familiar with command line programs. It is also ideal for batch scripts and if automated backup to KOPAH is desired.
 
-S3cmd is available for uploading data to KOPAH from your local computer and with usage on `klone`.
+s3cmd is available for uploading data to KOPAH from your local computer and with usage on `klone`.
 
-### Local S3cmd usage
+### Local s3cmd usage
 
-To get started with S3cmd, install the software on your local computer. [**Click here to Download S3cmd from the developer's website.**](https://s3tools.org/s3cmd)
+To get started with s3cmd, install the software on your local computer. [**Click here to Download s3cmd from the developer's website.**](https://s3tools.org/s3cmd)
 
-Create an S3cmd configuration file in your home directory. Call it `.s3cfg`. There are many ways to create this file. 
+Create an s3cmd configuration file in your home directory. Call it `.s3cfg`. There are many ways to create this file.
 
 #### For example, Mac and Linux users you can use the text editor `nano` in a Terminal window.
 
@@ -29,9 +29,9 @@ nano .s3cfg
 ## Use Ctrl + X to exit nano
 ```
 
-#### Windows users could use Wordpad or another text editor application. 
+#### Windows users could use Wordpad or another text editor application.
 
-`.s3cfg` should contain the following details: 
+`.s3cfg` should contain the following details:
 
 ```bash title=".s3cfg"
 [default]
@@ -44,15 +44,15 @@ access_key = <ACCESS_KEY>
 secret_key = <SECRET_KEY>
 ```
 
-Where the word `<ACCESS_KEY>` is replaced with your KOPAH Access Key and the word `<SECRET_KEY>` is replaced with your KOPAH Secret Key. 
+Where the word `<ACCESS_KEY>` is replaced with your KOPAH Access Key and the word `<SECRET_KEY>` is replaced with your KOPAH Secret Key.
 
-After that is complete. S3cmd can be used to access your KOPAH storage data with a large suite of commands. The S3cmd help includes example commands for a variety of tasks.
+After that is complete. s3cmd can be used to access your KOPAH storage data with a large suite of commands. The s3cmd help includes example commands for a variety of tasks.
 
 ```bash 
 s3cmd --help
 ```
 
-The following are a small collection of the many commands available with S3cmd. 
+The following are a small collection of the many commands available with s3cmd.
 
 | command | action|
 |---------|-------|
@@ -68,16 +68,16 @@ The following are a small collection of the many commands available with S3cmd.
 Buckets and objects shouldn't be public unless necessary, set them private whenever possible!
 :::
 
-### S3cmd usage on `klone`
+### s3cmd usage on `klone`
 
-S3cmd is installed for all `klone` users. Users need only set up their S3cmd configuration file in their home directory as shown above. 
+s3cmd is installed for all `klone` users. Users need only set up their s3cmd configuration file in their home directory as shown above.
 
 ```bash
 cd ~
 nano .s3cfg
 ## Use Ctrl + X to exit nano
 ```
-Prepare your `.s3cfg` file as shown above. 
+Prepare your `.s3cfg` file as shown above.
 
 ## S5cmd
 

--- a/docs/storage/cli.md
+++ b/docs/storage/cli.md
@@ -85,7 +85,17 @@ Prepare your `.s3cfg` file as shown above.
 
 ### Setup
 
-s5cmd is pre-installed on KLONE. To install locally, view the [**developer's instructions**](https://github.com/peak/s5cmd#installation).
+s5cmd is not installed on KLONE by default. To install s5cmd:
+
+1. Download the latest binary, currently 2.2.2: `wget  https://github.com/peak/s5cmd/releases/download/v2.2.2/s5cmd_2.2.2_Linux-64bit.tar.gz`
+2. Create local binary folder if not already exists: `mkdir -p ~/.local/bin`
+3. Unzip the s5cmd binary: `tar -xvzf s5cmd_2.2.2_Linux-64bit.tar.gz s5cmd`
+4. Move the binary to the correct location: `mv s5cmd ~/.local/bin/s5cmd`
+5. Delete the original archive: `rm s5cmd_2.2.2_Linux-64bit.tar.gz`
+
+:::note
+Installing s5cmd locally will likely be similar, make sure to consult their [installation documentation](s5cmd_2.2.2_Linux-64bit.tar.gz).
+:::
 
 s3cmd must be configured to interact with KOPAH. To do so, set the following environment variables in your shell.
 

--- a/docs/storage/cli.md
+++ b/docs/storage/cli.md
@@ -1,6 +1,6 @@
 ---
 id: cli
-title: S3 CLIs
+title: CLI Usage
 ---
 
 On this page we detail two options data on KOPAH via Command Line Interfaces (CLIs). s3cmd is a popular and widely used tool, while s5cmd is faster but less widely used.
@@ -11,7 +11,7 @@ These tools aren't the only ones compatible with KOPAH, however you will need to
 
 ## S3cmd
 
-S3cmd is a free command line tool and client for uploading, retrieving and managing data in KOPAH S3. It is best suited for power users who are familiar with command line programs. It is also ideal for batch scripts and if automated backup to S3 is desired.
+S3cmd is a free command line tool and client for uploading, retrieving and managing data in KOPAH. It is best suited for power users who are familiar with command line programs. It is also ideal for batch scripts and if automated backup to KOPAH is desired.
 
 S3cmd is available for uploading data to KOPAH from your local computer and with usage on `klone`.
 
@@ -46,7 +46,7 @@ secret_key = <SECRET_KEY>
 
 Where the word `<ACCESS_KEY>` is replaced with your KOPAH Access Key and the word `<SECRET_KEY>` is replaced with your KOPAH Secret Key. 
 
-After that is complete. S3cmd can be used to access your KOPAH S3 storage data with a large suite of commands. The S3cmd help includes example commands for a variety of tasks.
+After that is complete. S3cmd can be used to access your KOPAH storage data with a large suite of commands. The S3cmd help includes example commands for a variety of tasks.
 
 ```bash 
 s3cmd --help

--- a/docs/storage/gui.md
+++ b/docs/storage/gui.md
@@ -1,13 +1,13 @@
 ---
 id: gui
-title: S3 GUIs
+title: GUI Usage
 ---
 
-On this page we will provide options to interact with your S3 data on KOPAH via Graphical User Interfaces (GUIs).
+On this page we will provide options to interact with your data on KOPAH via Graphical User Interfaces (GUIs).
 
 ## Cyberduck 
 
-Cyberduck is an open-source client for managing and transferring files to various cloud storage services and servers, including FTP, SFTP, and S3. It offers a simple, intuitive interface that allows users to easily upload, download, and organize their files. Cyberduck is available for both Windows and macOS, making it a versatile tool for seamless file management across different platforms.
+Cyberduck is an open-source client for managing and transferring files to various cloud storage services and protocols, including FTP, SFTP, and S3. It offers a simple, intuitive interface that allows users to easily upload, download, and organize their files. Cyberduck is available for both Windows and macOS, making it a versatile tool for seamless file management across different platforms.
 
 To get started with Cyberduck, install the software on your local computer. [**Click here to Download Cyberduck from the developer's website.**](https://cyberduck.io/download/)
 

--- a/docs/storage/gui.md
+++ b/docs/storage/gui.md
@@ -5,17 +5,17 @@ title: GUI Usage
 
 On this page we will provide options to interact with your data on KOPAH via Graphical User Interfaces (GUIs).
 
-## Cyberduck 
+## Cyberduck
 
 Cyberduck is an open-source client for managing and transferring files to various cloud storage services and protocols, including FTP, SFTP, and S3. It offers a simple, intuitive interface that allows users to easily upload, download, and organize their files. Cyberduck is available for both Windows and macOS, making it a versatile tool for seamless file management across different platforms.
 
-To get started with Cyberduck, install the software on your local computer. [**Click here to Download Cyberduck from the developer's website.**](https://cyberduck.io/download/)
+To get started with Cyberduck, install the software from the [**developer's website**](https://cyberduck.io/download/) on your local computer.
 
 For ease of use, a pre-configured connection profile for KOPAH is available. Download the [profile](/files/kopah.cyberduckprofile) and open it in Cyberduck to load it. Saving the file with a `.cyberduckprofile` extension and double-clicking it within a file explorer should open it.
 
 Once setup, connect to KOPAH:
 
-1. Open a new Cyberduck window and locate the **Open Connection** Icon. 
+1. Open a new Cyberduck window and locate the **Open Connection** Icon.
 ![](/img/docs/kopah/cyberduck_open.png 'Open Connection')
 
 2. Select **KOPAH S3** from the drop-down box.
@@ -30,4 +30,4 @@ You can now interact with KOPAH using the GUI! Buckets can be created by right c
 
 ![](/img/docs/kopah/cyberduck_buckets.png 'Buckets')
 
-In the example above there are two buckets, `bucket1` and `bucket2`, each with one file. 
+In the example above there are two buckets, `bucket1` and `bucket2`, each with one file.

--- a/docs/storage/kopah.md
+++ b/docs/storage/kopah.md
@@ -1,14 +1,11 @@
 ---
 id: kopah
-title: What is KOPAH S3? 
+title: KOPAH Information
 ---
 
+Starting in Fall 2024, we will be offering our self-hosted, on-premises S3-API compatible object storage called KOPAH. 
 
-Starting in Fall 2024, we will be offering our self-hosted, on-premises S3-compatible object storage called KOPAH. 
-
-**S3 storage** is a solution for securely storing and managing large amounts of data, whether for personal use or research computing. It works like an online storage locker where you store can files of any size, accessible from anywhere with an internet connection. For researchers and those involved in data-driven studies, it provides a reliable and scalable platform to store, access, and analyze large datasets, supporting high-performance computing tasks and complex workflows. 
-
-S3 uses **buckets** as containers to store data, where each bucket can hold 100,000,000 **objects**, which are the actual files or data you store. Each object within a bucket is identified by a unique key, making it easy to organize and retrieve your data efficiently. Public links can be generated for KOPAH objects so that users can share buckets and objects with collaborators. 
+KOPAH uses **buckets** as containers to store data, where each bucket can hold 100,000,000 **objects**, which are the actual files or data you store. Each object within a bucket is identified by a unique key, making it easy to organize and retrieve your data efficiently. Public links can be generated for KOPAH objects so that users can share buckets and objects with collaborators.
 
 ## KOPAH Accounts
 KOPAH storage accounts can be requested by sending an email to help@uw.edu with "KOPAH" in the subject line. Opening a KOPAH storage account required a valid UW Budget and Worktag. 
@@ -24,10 +21,10 @@ Where the word "BUCKET" above is replaced with the name of your storage bucket.
 
 ## KOPAH Usage Tools
 
-KOPAH S3 is compatible with many S3 client tools, which are numerous. Here we have included some examples of tools you might find useful for interacting with KOPAH:
+KOPAH is compatible with many S3-API client tools, which are numerous. Here we have included some examples of tools you might find useful for interacting with KOPAH:
 
-* [**Graphical User Interface tools for KOPAH**](https://hyak.uw.edu/docs/storage/gui): solutions under this option include Graphical User Interfaces (GUIs) that offer convenient upload options like drag-and-drop from your local computer to KOPAH S3. 
+* [**Graphical User Interface tools for KOPAH**](https://hyak.uw.edu/docs/storage/gui): solutions under this option include Graphical User Interfaces (GUIs) that offer convenient upload options like drag-and-drop from your local computer to KOPAH. 
 
-* [**Command Line Interface tools for KOPAH**](https://hyak.uw.edu/docs/storage/cli): solutions under this option include Command Line Interfaces (CLIs) that can be used to upload files from your local computer to KOPAH S3 and can be used on Hyak's current generation cluster, `klone` to complete transfers prior to computing against the data.
+* [**Command Line Interface tools for KOPAH**](https://hyak.uw.edu/docs/storage/cli): solutions under this option include Command Line Interfaces (CLIs) that can be used to upload files from your local computer to KOPAHand can be used on Hyak's current generation cluster, `klone` to complete transfers prior to computing against the data.
 
 

--- a/docs/storage/kopah.md
+++ b/docs/storage/kopah.md
@@ -3,12 +3,12 @@ id: kopah
 title: KOPAH Information
 ---
 
-Starting in Fall 2024, we will be offering our self-hosted, on-premises S3-API compatible object storage called KOPAH. 
+Starting in Fall 2024, we will be offering our self-hosted, on-premises S3-API compatible object storage called KOPAH.
 
 KOPAH uses **buckets** as containers to store data, where each bucket can hold 100,000,000 **objects**, which are the actual files or data you store. Each object within a bucket is identified by a unique key, making it easy to organize and retrieve your data efficiently. Public links can be generated for KOPAH objects so that users can share buckets and objects with collaborators.
 
 ## KOPAH Accounts
-KOPAH storage accounts can be requested by sending an email to help@uw.edu with "KOPAH" in the subject line. Opening a KOPAH storage account required a valid UW Budget and Worktag. 
+KOPAH storage accounts can be requested by sending an email to help@uw.edu with "KOPAH" in the subject line. Opening a KOPAH storage account required a valid UW Budget and Worktag.
 
 ## KOPAH Access
 You will need access key and secret key to access your Kopah account. When you open an account your keys are placed in your home directory on `klone` in a file called `kopah_groupname`, where the word "groupname" is associated Hyak group.
@@ -17,7 +17,7 @@ S3 endpoint for KOPAH is https://s3.kopah.orci.washington.edu
 
 Bucket endpoint format is https://s3.kopah.orci.washington.edu/BUCKET
 
-Where the word "BUCKET" above is replaced with the name of your storage bucket. 
+Where the word "BUCKET" above is replaced with the name of your storage bucket.
 
 ## KOPAH Usage Tools
 
@@ -26,5 +26,3 @@ KOPAH is compatible with many S3-API client tools, which are numerous. Here we h
 * [**Graphical User Interface tools for KOPAH**](https://hyak.uw.edu/docs/storage/gui): solutions under this option include Graphical User Interfaces (GUIs) that offer convenient upload options like drag-and-drop from your local computer to KOPAH. 
 
 * [**Command Line Interface tools for KOPAH**](https://hyak.uw.edu/docs/storage/cli): solutions under this option include Command Line Interfaces (CLIs) that can be used to upload files from your local computer to KOPAHand can be used on Hyak's current generation cluster, `klone` to complete transfers prior to computing against the data.
-
-


### PR DESCRIPTION
- Clarifies terminology between KOPAH and S3.
- Adds documentation for s5cmd.
- Adds additional s3cmd information on making a bucket private.
- Minor text edits.