### PR TITLE
Prerequisite added to VSCode ProxyJump method

### DIFF
--- a/docs/hyak101/python/slurm-forward.md
+++ b/docs/hyak101/python/slurm-forward.md
@@ -73,6 +73,22 @@ NODE=$(ssh klone-login 'squeue \
     --noheader ')
 sed -I '' -E s"/Hostname.*/Hostname $NODE/" ~/.ssh/klone-node-config
 ```
+:::note
+For at least one other version of `sed` this script works after a small adjustment. If the script version above doesn't work for you, try the following: 
+
+```bash title="set-hyak-node.sh"
+#!/bin/bash
+NODE=$(ssh klone-login 'squeue \
+    --user $USER \
+    --states RUNNING \
+    --name klone-container \
+    --Format NodeList \
+    --noheader ')
+    //highlight-next-line
+sed -i -E s"/Hostname.*/Hostname $NODE/" ~/.ssh/klone-node-config
+```
+:::
+
 
 Don't forget to make the script executable. 
 ```bash

--- a/docs/tools/vsc-proxy-jump.md
+++ b/docs/tools/vsc-proxy-jump.md
@@ -12,8 +12,83 @@ title: VS Code via ProxyJump
 3. Requires: the set up of primary and secondary configuration files on your local computer, key-pair configuration, launching an interactive job, use of the `Remote-SSH` extension to connect to a compute node on `klone`.
 
 :::warning MAC vs. Windows
-In the next exercise, some of the instructions differ for Mac and Windows users. 
+In this section, some of the instructions differ for Mac and Windows users. 
 :::
+
+
+### Crucial Prerequisite
+
+In the next steps you will be setting up a configuration that will require the use of SSH key pairs. This is a common security measure used when connecting to remote hosts. You will use TWO key pairs. One allows Hyak `klone` cluster to recognize your local computer and the other allows you to move between the `klone` login node and a compute node where you have a job running. 
+
+#### A Keypair for `klone` to recognize your local computer. 
+
+First, ensure you have a SSH public and private keypair for your local computer. You may have set this up in the past. From your Home directory on your local computer, search for `id_rsa` and `id_rsa.pub` the one ending in `.pub` is the public part of the key pair that you will share with `klone` to decode your private key and log on securely. These should be in a directory `~/.ssh` on your local computer. 
+
+```bash
+cd ~/.ssh
+```
+
+If you don't have `id_rsa` and `id_rsa.pub` on your local computer, you should generate a new keypair with the following command: 
+```bash
+ssh-keygen -t rsa -b 4096
+```
+
+The public key should look something like the following: 
+
+:::caution important
+Search for `id_rsa.pub` under `~/.ssh` on your local computer. 
+:::
+
+```bash title="id_rsa.pub"
+ssh-rsa AAAAB3NzaC1...SOME_STRING...FbFvEYcw== username@user-Device
+```
+Where it starts with ssh-rsa, contains some long and seemingly-random string, and ends with the username for your computer `@` the name of your computer. You will want to copy this key and paste it into a file called `authorized_keys` on `klone` in your Home Directory under the directory `.ssh`. 
+
+:::caution important
+Paste the contents of your `id_rsa.pub` into `~/.ssh/authorized_keys` on `klone`. 
+:::
+
+```bash title="~/.ssh/authorized_keys"
+ssh-rsa AAAAB3NzaC1...SOME_STRING...FbFvEYcw== username@user-Device
+```
+You can do this manually with copy and paste, or with the command
+```bash
+ssh-copy-id klone-login
+```
+Below you will be prompted to do this, but we wanted to give you the tools to set this up now. This is a common stumbling block for completing this method for setting up VS Code on Hyak. 
+
+#### A Keypair to navigate between nodes on `klone` with ssh.
+
+:::warning
+Here is where things get confusing because we will use the same protocol to also generate a second keypair  and the fie names below will be repeated. If you get confused, **please read the instructions again carefully**. If you are still stuck, please email help@uw.edu with "Hyak" in the subject line to ask for assistance. 
+:::
+
+Your next required keypair is called an [**Intracluster SSH Key, which we explained elsewhere in our docs**](https://hyak.uw.edu/docs/setup/intracluster-keys). This pair is for navigating between nodes on `klone` with ssh (Intracluster = Within `klone`, get it?). 
+
+**ON `klone`** execute the following command
+```bash
+ssh-keygen -C klone -t rsa -b 2048 -f ~/.ssh/id_rsa -q -N ""
+```
+This command creates a 2048-bit RSA key with `klone` in the comment field and will look something like the following
+```bash title="id_rsa.pub"
+ssh-rsa AAAAB3NzaC1...SOME_OTHER_STRING...FbFvEYcw== klone
+```
+Next, add the contents of your public key to the `authorized_keys` file in your home directory with the follow commands:
+```bash
+cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+```
+This also also ensures the `authorized_keys` file has appropriate permissions.
+
+Your `authorized_keys` file should have at least two keypairs: one for your local computer and one for `klone`. 
+```bash 
+cat ~/.ssh/authorized_keys
+```
+```bash title="~/.ssh/authorized_keys"
+ssh-rsa AAAAB3NzaC1...SOME_STRING...FbFvEYcw== username@user-Device
+ssh-rsa AAAAB3NzaC1...SOME_OTHER_STRING...FbFvEYcw== klone
+```
+
 
 :::important
 
@@ -103,11 +178,13 @@ This file will also need the correct permissions. **Windows should not require a
 chmod 600 ~/.ssh/klone-node-config
 ```
 
-Because you will be effectively connecting directly from your local computer to the node, you will need to append the SSH public key from your **local** system to the `~/.ssh/authorized_keys` file under your cluster home directory on `klone`. This command will update your authorized keys list. 
+:::note
+You may have already completed this step as a prerequisite, but here it is again just in case. Because you will be effectively connecting directly from your local computer to the node, you will need to append the SSH public key from your **local** system to the `~/.ssh/authorized_keys` file under your cluster home directory on `klone`. This command will update your authorized keys list. 
 
 ```bash
 ssh-copy-id klone-login
 ```
+:::
 
 Or you can do the same by copying your local ssh key into `~/.ssh/authorized_keys` file on `klone`. While we cannot use our key as a authentication factor between our local machine and klone, we can use it when ssh'ing *between* klone nodes.
 
@@ -158,11 +235,10 @@ We will use this short cut (ProxyJump) with the `Remote-SSH` extension of VS Cod
 :::tip PRO TIP
 Manually editing `~/.ssh/klone-node-config` everytime you want to connect VS Code is tedious and prone to error. Use the following bash script **ON YOUR COMPUTER** to get the hostname of the compute node you wish to connect to with your ProxyJump. [**Download the script here**](https://hyak.uw.edu/files/set-hyak-node.sh).
 
-**WARNING this script doesn'tusually work on Windows since bash and sed are not available. AND it might not work if you have a different version of sed**
+**WARNING this script doesn'tusually work on Windows since bash and sed are not available. If might work if your re on Windows with WSL or Gitbash. MOREOVER, it might not work if you have a different version of sed**
 
 ```bash title="set-hyak-node.sh"
 #!/bin/bash
-set -euo pipefail
 NODE=$(ssh klone-login 'squeue \
     --user $USER \
     --states RUNNING \
@@ -182,6 +258,22 @@ This script works by setting the variable `NODE` and modifying `~/.ssh/klone-nod
 1. The `ssh klone-login` command to login with your short cut. 
 2. The `squeue` command to view your Slurm jobs **named `vsc-proxy-jump`**.
 3. The `sed` command then modifies `~/.ssh/klone-node-config` in place by searching `~/.ssh/klone-node-config` for "Hostname" followed by any number of any characters (`.*`), and replaces it with "Hostname $NODE" where `$NODE` is the node running your job called "vsc-proxy-jump" (`n3120` in this example).
+:::
+
+:::note
+For at least one other version of `sed` this script works after a small adjustment. If the script version above doesn't work for you, try the following: 
+
+```bash title="set-hyak-node.sh"
+#!/bin/bash
+NODE=$(ssh klone-login 'squeue \
+    --user $USER \
+    --states RUNNING \
+    --name vsc-proxy-jump \
+    --Format NodeList \
+    --noheader ')
+  //highlight-next-line
+sed -i -E s"/Hostname.*/Hostname $NODE/" ~/.ssh/klone-node-config
+```
 :::
 
 ### Connect VS Code to Node via ProxyJump


### PR DESCRIPTION
feedback from user tickets shows that Intracluster Keys should be a listed prerequisite for VSCode proxyjump. Additionally, a sed alternative solution added for set-hyak-node.sh scripts.