### PR TITLE
Necessary Updates

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -124,6 +124,14 @@ module.exports = {
               label: 'School of Medicine',
               href: 'https://www.uwmedicine.org/school-of-medicine',
             },
+            {
+              label: 'UW Bothell',
+              href: 'https://www.uwb.edu/',
+            },
+            {
+              label: 'UW Tacoma',
+              href: 'https://www.tacoma.uw.edu/',
+            },
           ],
         },
         {

--- a/src/pageContent.js
+++ b/src/pageContent.js
@@ -7,9 +7,9 @@ export const HEAD_TITLE = 'Home'
 export const HEAD_DESC = 'Hyak Supercomputer'
 
 export const STAT_ITEMS = {
-  'Researchers': '2,061',
-  'Compute Cores': '21,028',
-  'GPUs': '576',
+  'Researchers': '2,680',
+  'Compute Cores': '30,932',
+  'GPUs': '832',
 }
 
 export const HomePage = {

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -26,17 +26,89 @@ export default function Pricing() {
         <div class="row">
           <div class="col">
             <a name="condo-model" />
+            <p>The Hyak Supercomputing Research Cluster is part of an integrated, scalable, scientific super-computing infrastructure operated by UW-IT. It includes a high-performance research network, the Hyak compute infrastructure (HPC and GPU clusters), and scientific support services available to consult on in your research workflows. The Science DMZ network supports fast data transfers among these systems and upstream to the rest of campus over the Internet.</p>
             <h3>Condo Model</h3>
-            <p>The Hyak clusters operate on a condo model. This means that the cluster itself consists of contributed resource slices from various groups across campus. The Hyak team, funded through the office of research and sponsoring entities, provides the core infrastructure (e.g., networking, storage, support staff). This is why faculty that are from sponsoring entities do not have any annual, ongoing costs associated with their slices beyond the initial cost of the hardware. The leadership of their sponsoring entities cover this. Faculty that are <u>not</u> affiliated with sponsoring entities have to shoulder this annual, ongoing cost associated with any slices they wish to contribute.</p>
-            <p>You get access to resources equivalent to the slices your account contributes to the cluster on-demand. A cluster account also provides you access to all the other contributed slices from other entities, subject to their availability (i.e., if the contributors or the resources aren't actively using them). This is referred to as the "checkpoint" partition due to the lack of job run-time guarantees. Once a checkpoint job starts it can be re-queued at any moment, but is not uncommon for a job to run for 4 to 5 hours before requeue. Longer checkpoint jobs will continue to run and be re-queued until they complete, which is why it is important that your job be able to checkpoint or save state and resume gracefully. Checkpoint access can provide access to substantial resources beyond what you contribute and is the benefit of joining a shared cluster like Hyak compared to buying the same hardware operating your own server.</p>
-            The total cost considerations for compute nodes in Hyak can be broken down into the sum of the following two components.
+            <p>The Hyak Supercomputing Research Cluster operates under a condo model common across many universities. In a condo model, the cluster consists of contributed slices from various groups across campus, and the Hyak team provides the core infrastructure (e.g., networking, storage, and support staff). Faculty, researchers, and some associates with affiliated organizations may purchase slices. Slice owners, members of their research group, and any collaborators get access to resources equivalent to your contributed slices on-demand.</p>
+            <p>As a member of the Hyak community, you also receive access to all contributed slices from other entities, subject to their availability (i.e., if the contributors or the resources aren't actively using them). This is referred to as the <a href="https://hyak.uw.edu/docs/compute/checkpoint#the-checkpoint-partition"><b>"checkpoint" partition</b></a> due to the lack of job run-time guarantees. Checkpoint provides access to substantial resources beyond what you contribute and is the benefit of joining the Hyak ecosystem rather than buying the same hardware and operating your own server.</p>
+            The total cost for Hyak compute slices can be broken down into the sum of the following two components.
             <ol>
-              <li><a href="#slice-cost-annual">Slice Annual Costs</a></li>
-              <li><a href="#slice-cost-hardware">Slice Hardware Costs</a></li>
+              <li><a href="#slice-cost-hardware"><b>Slice Hardware Costs</b></a></li>
+              <li><a href="#slot-fee-annual"><b>Annual Slot Fees</b></a></li>
             </ol>
 
-            <a name="slice-cost-annual" />
-            <h3>Slice Annual Costs</h3>
+            <a name="slice-cost-hardware" />
+            <h3>Slice Hardware Configurations</h3>
+
+            <p>We currently offer HPC slices and GPU slices. Our current slice offering specifications are based on market price and availability. To request detailed Hyak slice pricing and information, please complete the <a href="https://uwconnect.uw.edu/sp?id=sc_cat_item&sys_id=56f324af0faa6bc06cad419ce1050ed2"><b>Hyak Slice Pricing and Purchase Information Request Form</b></a>. Current configurations:</p>
+            <p>
+              <h4>Next-gen HPC slices (AMD):</h4>
+              <ul>
+                <li>256GB: $3,892.00 (pending delivery and installation). <b>ORDER TODAY! Limited inventory remaining on current order.</b></li>
+              </ul>
+              <h4>GPU slices (Nvidia):</h4>
+              <ul>
+                <li>L40S: 32-cores, 384GB, 2 x L40S GPUs (w/48GB per card) last quoted $17,889.75 (pending order and delivery).</li>
+                <li>H200: 32-cores, 384GB, 2 x H200 (w/141GB per card) $58,910.25 (pending order and delivery; requires at least four slice purchases before an order can be made)</li>
+              </ul>
+              <p>Additional RAM may NOT be added to a slice after it is purchased; however additional slices can be added to the equivalent desired RAM.</p>
+              <a href="https://uwconnect.uw.edu/sp?id=sc_cat_item&sys_id=56f324af0faa6bc06cad419ce1050ed2"><button class="button button--secondary button--block">Buy Slices</button></a>
+            </p>
+
+            <p>
+              <h4>Storage:</h4>
+                <ul>
+                  <li>All slices include 1 TB of storagespace and a 1 million file count limit of shared group storage (i.e., gscratch) accessible from every node. You may purchase supplemental storage at a monthly rate of $10.00 per TB per month (with a limit of 1 million inodes per TB). Supplemental storage subscripts are subject to indirect costs. Storage prices are subject to revision annually. To request supplemental storage, email <b>help@uw.edu</b> with "Hyak gscratch" in the subject line.</li>
+                  <li>Additional shared storage called <a href="https://hyak.uw.edu/docs/storage/gscratch#scrubbed"><b>"scrubbed"</b></a> is available for short-term use, but will be automatically deleted if not accessed for several weeks.</li>
+                </ul>
+            </p>
+
+            <p>
+              <h4>General FAQ:</h4>
+              <ul>
+                <li>All hardware is procured at cost (market value with substantial university negotiated bulk discounts) and no sales tax or university overhead applied.</li>
+                <li>We reserve the 2nd Tuesday of every month for cluster maintenance.</li>
+                <li>Hyak slices are supported for a minimum guaranteed lifetime of 4 or 5 years depending on the slice type. Beyond 4 or 5 years all slices are continued to be made available subject to hardware viability and the sponsoring entity still having capacity. Self-sponsored slices have an on-going annual cost, this means slice life is reviewed on a yearly basis subject to the lab's willingness to continue, hardware viability, and overall cluster capacity (see below for more about <a href="#slice-cost-annual"><b>Sponsored vs. Self-sposored slices</b></a>). Historically, slice service life has been 6 years on average. However, past performance is not a <i>guarantee</i> of future experiences.</li>
+                <li><h5>HPC Slices:</h5></li>
+                  <ul>
+                    <li>All slices are standardized on AMD EPYC 9654 CPUs ("Genoa").</li>
+                    <li>A physical server (or node) has 192-cores and &gt;1.5TB of memory packaged in a single box. This is in turn sub-divided into 6 equal "slices" that are resources of compute units that are sold to researchers.</li>
+                    <li>Each node has 1.5TB or more of local NVME SSD disk storage. This is non-persistent storage and is cleared after a job ends. Data must be copied to and from local SSD before and after each job to utilize this.</li>
+                    <li>Nodes are identically configured.</li>
+                    <li>Any jobs requiring multiple nodes should be prepared to be independent computations (i.e., "embarassingly parallel") or make use of message passing libraries (e.g., OpenMPI) to scale across multiple nodes simultaneously.</li>
+                  </ul>
+                <li><h5>GPU Slices:</h5></li>
+                  <ul>
+                    <li>All slices are standardized on AMD EPYC 9534 CPUs ("Genoa"). We are on the NVIDIA "Ada" and "Hopper" generation of GPUs.</li>
+                    <li>4 x GPU slices constitute a single physical server (or node). It is a single box with 128-cores, 1.5TB of memory, and 8 x GPUs of the same type. They are sold in resource slices to make this a more tractable cost for labs with more modest GPU needs.</li>
+                    <li>Any jobs requiring more than 8 x GPUs of the same type should be prepared to make use of message passing libraries (e.g., PyTorch Lightning) to scale across multiple servers. Any job up to the equivalent of 4 x GPU slices (i.e., 8 x GPU cards) can be run on the same physical machine and therefore scale easily without much further modification to the codebase.</li>
+                  </ul>
+              </ul>
+              <a href="https://uwconnect.uw.edu/sp?id=sc_cat_item&sys_id=56f324af0faa6bc06cad419ce1050ed2"><button class="button button--secondary button--block">Buy Slices</button></a>
+            </p>
+
+            <a name="slot-fee-annual" />
+            <h3>Annual Costs</h3>
+
+            <p>
+            In addition to the hardware purchase costs above, Hyak slices may also be subject to annual maintenance fees (called slot fees) charged to sponsoring entities (listed below). Annual slot fees could be up to $800 for a HPC slice (1 slot), up to $1,200 for a L40S GPU slice (1.5 slots), and up to $1,600 for an H200 slice (2 slots). Prospective Hyak slice owners that are not associated with a sponsor are responsible for annual slot fees, which amount to $1,750 for HPC slices (1 slot), $2,625 for L40S GPU slices (1.5 slots), and $3,500 for H200 slices (2 slots). The difference in the number of slots occupied by a slice depends on the energy consumption of the slice, and GPU slices consume more energy. 
+            </p>
+
+            <p>
+            <i><b>The Hyak sponsor chooses if and how to recuperate annual slot fees. Please consult your College IT director or Department Chair to determine the slot fees you can expect to pay annually.</b></i>
+            </p>
+
+            <b>Sponsors</b>:
+            <ul>
+              <li>UW Seattle</li>
+              <ul>
+                <li>College of Arts & Sciences</li>
+                <li>College of Engineering</li>
+                <li>College of the Environment</li>
+                <li>School of Medicine</li>
+              </ul>
+              <li>UW Bothell</li>
+              <li>UW Tacoma</li>
+            </ul>
 
             <div class="row">
   
@@ -44,17 +116,16 @@ export default function Pricing() {
                 <div class="card-demo">
                   <div class="card">
                     <div class="card__header">
-                      <h5>Self-Sponsored Slices (Annual)</h5>
-                      <h3>$1,750 / 1 slice / 1 year</h3>                      
+                      <h5>Annual Slot Fees for Sponsored Slices</h5>
+                      <h3>Up to $800 / 1 slot / 1 year</h3>                      
                     </div>
                     <div class="card__footer">
-                      <a href="mailto:help@uw.edu?subject=buy hyak (self-sponsored) slices&body=I would like to get some hyak self-sponsored slices.">
-                      <button class="button button--secondary button--block">Get Self-Sponsored Slices</button></a>
+                    <a href="https://uwconnect.uw.edu/sp?id=sc_cat_item&sys_id=56f324af0faa6bc06cad419ce1050ed2"><button class="button button--secondary button--block">Buy Slices</button></a>
                     </div>
                     <div class="card__body">
                       What's included?
                       <ul class="check">
-                        <li>Cluster membership evaluated annually.</li>
+                        <li>Slice lifetime guaranteed for a minimum of 4 or 5 years depending on the slice type.</li>
                         <li>Access to the checkpoint partition for additional resources and compute time beyond what you contribute to the cluster.</li>
                         <li>Grant application support.</li>
                         <li>Scientific consultation for workflows and researcher onboarding.</li>
@@ -74,19 +145,17 @@ export default function Pricing() {
                 <div class="card-demo">
                   <div class="card">
                     <div class="card__header">
-                      <h5>Sponsored Slices (Annual)</h5>
-                      <h3>$0 / year</h3>
+                      <h5>Annual Slot Fees for Self-Sponsored Slices</h5>
+                      <h3>$1,750 / year</h3>
                     </div>
                     <div class="card__footer">
-                    <a href="mailto:help@uw.edu?subject=buy hyak (sponsored) slices&body=I would like to get some hyak sponsored slices.">
-                      <button class="button button--secondary button--block">Get Sponsored Slices</button></a>
+                    <a href="https://uwconnect.uw.edu/sp?id=sc_cat_item&sys_id=56f324af0faa6bc06cad419ce1050ed2"><button class="button button--secondary button--block">Buy Slices</button></a>
                     </div>
                     <div class="card__body">
                     What's included?
                       <ul class="check">
-                        <li>Everything that comes with self-sponsored slices.</li>
-                        <li>Slice lifetime guaranteed for a minimum of 4 years.</li>
-                        <li>No annual costs beyond the up front cost of the slices.</li>
+                        <li>Everything that comes with sponsored slices.</li>
+                        <li>Cluster membership can be evaluated annually.</li>
                       </ul>
                       <p>NOTE: Slices purchased separately (below).</p>
                     </div>
@@ -97,113 +166,6 @@ export default function Pricing() {
             </div>
 
             <br />
-
-            <p>
-              If your lab has a faculty affiliation with a sponsoring entity (listed below), then you are only responsible for a one time, total up-front cost of the slices. You get 4 years of guaranteed and fully supported utilization per slice and beyond that subject to capacity and other conditions. You can skip down to the section below for specific slice configurations.
-            </p>
-
-            <p>
-              If your lab does <u>not</u> have a faculty affiliation with a sponsoring entity (listed below), then there is an annual cost of $1,750 per 1 slice per 1 year (Self-Sponsored Slices above).
-            </p>
-
-            <b>Sponsors</b>:
-            <ul>
-              <li>UW Seattle</li>
-              <ul>
-                <li>College of Arts & Sciences</li>
-                <li>College of Engineering</li>
-                <li>College of the Environment</li>
-                <li>Institute for Protein Design</li>
-                <li>School of Medicine</li>
-              </ul>
-              <li>UW Bothell</li>
-              <li>UW Tacoma</li>
-            </ul>
-
-            <a name="slice-cost-hardware" />
-            <h3>Slice Hardware Configurations</h3>
-            <table style={{"margin-left": "auto", "margin-right": "auto", "text-align": "center"}}>
-              <tr>
-                <td>Type</td>
-                <td colspan="3">HPC Slices</td>
-                <td colspan="2">GPU Slices</td>
-              </tr>
-              <tr>
-                <td>Slice Count</td>
-                <td colspan="3">1 x HPC slice</td>
-                <td colspan="2">1 x GPU slice</td>
-              </tr>
-              <tr>
-                <td>Name</td>
-                <td>standard</td>
-                <td>bigmem</td>
-                <td>custom</td>
-                <td>L40</td>
-                <td>H100</td>
-              </tr>
-              <tr>
-                <td>Compute Cores</td> 
-                <td colspan="5">32-cores</td>
-              </tr>
-              <tr>
-                <td>Memory (System)</td>
-                <td colspan="1">256GB</td>
-                <td colspan="1">512GB</td>
-                <td colspan="1">&gt;512GB</td>
-                <td colspan="2">384GB</td>
-              </tr>
-              <tr>
-                <td>GPU Type</td>
-                <td colspan="3">N/A</td>
-                <td>2 x L40</td>
-                <td>2 x H100</td>
-              </tr>
-              <tr>
-                <td>Memory (GPU)</td>
-                <td colspan="3">N/A</td>
-                <td>48GB per GPU</td>
-                <td>80GB per GPU</td>
-              </tr>
-              <tr>
-                <td>Pricing ($)</td>
-                <td colspan="3"><a href="mailto:help@uw.edu?subject=hyak hpc slice pricing&body=I am curious about the latest HPC slice pricing.">Email Us</a></td>
-                <td colspan="2"><a href="mailto:help@uw.edu?subject=hyak gpu slice pricing&body=I am curious about the latest GPU slice pricing.">Email Us</a></td>
-              </tr>
-            </table>
-
-            <p>
-              <h3>General FAQ:</h3>
-              <ul>
-                <li>All hardware is procured at cost (market value with substantial university negotiated bulk discounts) and no sales tax or university overhead applied.</li>
-                <li>We reserve the 2nd Tuesday of every month for cluster maintenance.</li>
-                <li><b>Slice Service Life</b>:</li>
-                <ul>                  
-                  <li>Sponsored Slices: All sponsored slices are supported for a minimum guaranteed lifetime of 4 years. Beyond 4 years all slices are continued to be made available subject to hardware viability (i.e., it didn't break) and the sponsoring entity still having capacity. Historically, this has been 6 years on average. However, past performance is not a <i>guarantee</i> of future experiences.</li>
-                <li>Self-Sponsored Slices: Since self-sponsored slices have an on-going annual cost, this means slice life is reviewed on a yearly basis subject to the lab's willingness to continue, hardware viability, and overall cluster capacity.</li>
-                </ul>
-                <li><b>Storage</b>:</li>
-                <ul>
-                  <li>Local: Each full node has 1.5TB or more of local NVME SSD disk storage. This is non-persistent storage and is cleared after a job ends. Data must be copied to and from local SSD before and after each job to utilize this.</li>
-                  <li>Group: Each slice purchase includes 1 TB of storage space and a 1 million file count limit of shared group storage (i.e., gscratch) accessible from every node. Additional storage quota increases can be purchased for $10 per month for 1TB of additional space and 1 million additional file count limit. Additional "scrubbed" shared storage is available for short-term use, but will be automatically deleted if not accessed for several weeks.</li>
-                </ul>
-              </ul>
-              HPC Slices:
-              <ul>
-                <li>All slices are standardized on AMD EPYC 9654 CPUs ("Genoa").</li>
-                <li>A physical server (or node) has 192-cores and &gt;1.5TB of memory packaged in a single box. This is in turn sub-divided into 6 equal "slices" that are resources of compute units that are sold to researchers.</li>
-                <li>They are identically configured with your choice of memory (or RAM).</li>
-                <li>Any jobs requiring multiple nodes should be prepared to be independent computations (i.e., "embarassingly parallel") or make use of message passing libraries (e.g., OpenMPI) to scale across multiple nodes simultaneously.</li>
-              </ul>
-              GPU Slices:
-              <ul>
-              <li>All slices are standardized on AMD EPYC 9534 CPUs ("Genoa"). We are on the NVIDIA "Ada" and "Hopper" generation of GPUs.</li>
-                <li>4 x GPU slices constitute a single physical server (or node). It is a single box with 128-cores, 1.5TB of memory, and 8 x GPUs of the same type. They are sold in resource slices to make this a more tractable cost for labs with more modest GPU needs.</li>
-                <li>Any jobs requiring more than 8 x GPUs of the same type should be prepared to make use of message passing libraries (e.g., PyTorch Lightning) to scale across multiple servers. Any job up to the equivalent of 4 x GPU slices (i.e., 8 x GPU cards) can be run on the same physical machine and therefore scale easily without much further modification to the codebase.</li>
-              </ul>
-            </p>
-
-            <a href="mailto:help@uw.edu?subject=buying hyak slices&body=I would like to get some hyak slices.">
-            <button class="button button--secondary button--block">Buy Slices</button></a>
 
           </div>
         </div>

--- a/src/pages/systems.js
+++ b/src/pages/systems.js
@@ -115,10 +115,10 @@ export default function systems() {
               <td align="right">Operating System</td><td>Rocky 8</td>
             </tr>
             <tr>
-              <td align="right">Compute</td><td>21,028 CPU cores [Cascade Lake, Ice Lake]</td>
+              <td align="right">Compute</td><td>30,932 CPU cores [AMD Genoa, Intel Cascade Lake, Intel Ice Lake]</td>
             </tr>
             <tr>
-              <td align="right">Accelerators</td><td>576 GPU cards [Turing, Ampere]</td>
+              <td align="right">Accelerators</td><td>832 GPU cards [Turing, Ampere]</td>
             </tr>
             <tr>
               <td align="right">Interconnect</td><td>100 Gbps [HDR100 Infiniband]</td>


### PR DESCRIPTION
Pricing page:

- Reorganized sections so that Hardware prices and information were listed first. Slot fees listed second. 
- Slot fees explained in more detail and listing a range of fees one might expect. 
- IPD removed as a sponsor.
- All buy slices buttons directed to the Hyak intake form that appears on the Hyak service catalog page and is being updated to be more useful. 
- Links to difference sections of Docs made BOLD. 
- Current prices and configs listed. 

Systems page: 

- Big cards (PageContent.js) CPU, GPU, and researcher counts updated based on Nam's end 2024 email and count of home directories. 
- CPU, GPU, and researcher counts updated in klone section table (systems.js)

Footer (docusaurus.config.js):

- UW Bothell and UW Tacoma added to sponsor list hot links. 