### PR TITLE
Documentation rearrangement (first of many)

### DIFF
--- a/docs/tillicum/tillicum.md
+++ b/docs/tillicum/tillicum.md
@@ -1,0 +1,8 @@
+---
+id: tillicum
+title: COMING SOON
+---
+
+Tillicum is the University of Washington’s next-generation AI-accelerated research computing platform coming in Fall 2025. 
+
+

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -49,21 +49,21 @@ module.exports = {
           position: 'right',
         },
         {
-          to: 'pricing',
+          to: 'https://uwconnect.uw.edu/it?id=kb_article_view&sysparm_article=KB0035560',
           label: 'Pricing',
           position: 'right',
           items: [
             {
-              label: 'Compute',
-              to: '/pricing',
+              label: 'Compute: Hyak Klone',
+              to: 'https://uwconnect.uw.edu/it?id=kb_article_view&sysparm_article=KB0035560',
             },
             {
-              label: 'Storage',
-              to: '/storage',
+              label: 'Try Hyak Klone',
+              to: 'https://uwconnect.uw.edu/sp?id=sc_cat_item&sys_id=f5caba8fdbe108101ba12968489619e0',
             },
             {
-              label: 'Try Hyak',
-              to: '/demo',
+              label: 'Research Storage',
+              to: 'https://uwconnect.uw.edu/it?id=kb_article_view&sysparm_article=KB0035580',
             },
           ]
         },
@@ -72,6 +72,21 @@ module.exports = {
           activeBasePath: 'docs',
           label: 'Documentation',
           position: 'right',
+        },
+                {
+          to: 'https://www.youtube.com/playlist?list=PL-uLiqrTav1omqc7omKsLzRg2ng3nKCtj',
+          label: 'Training Videos',
+          position: 'right',
+          items: [
+            {
+              label: 'Short How-Tos',
+              to: 'https://www.youtube.com/playlist?list=PL-uLiqrTav1qqP5bXbyd6dMNWnV35s9hg',
+            },
+            {
+              label: 'Recording Training',
+              to: 'https://www.youtube.com/playlist?list=PL-uLiqrTav1omqc7omKsLzRg2ng3nKCtj',
+            },
+          ]
         },
         {
           to: 'https://calendar.washington.edu/sea_uwit-rc',

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,67 +1,83 @@
 module.exports = {
   someSidebar: {
-    'Get Started': [
-      'index',
-      'join-group',
-      'account-creation',
-      'account-activation',
-    ],
-    'Setup': [
-      //'setup/index',
-      'setup/ssh',
-      'setup/intracluster-keys',
-      'setup/portforwarding',
-      'setup/x11'
-      //'setup/vscode',
-    ],
-    'Storage': [
-      'storage/data',
-      'storage/gscratch',
+    'Hyak Klone': [
       {
-        'Data Transfer': [
-          'storage/transfer',
-          'storage/cyberduck',
-          'storage/globus',
+        'Get Started': [
+          'index',
+          'join-group',
+          'account-creation',
+          'account-activation',
         ]
       },
-      'storage/archive',
       {
-        'Kopah S3 Storage': [
-          'storage/kopah',
-          'storage/gui',
-          'storage/cli',
-          'storage/boto3',
-          'storage/juicefs',
+        'Setup': [
+          'setup/ssh',
+          'setup/intracluster-keys',
+          'setup/portforwarding',
+          'setup/x11',
+        ]
+      },
+      {
+        'Storage': [
+          'storage/data',
+          'storage/gscratch',
+          {
+            'Data Transfer': [
+              'storage/transfer',
+              'storage/cyberduck',
+              'storage/globus',
+            ]
+          },
+          'storage/archive',
+        ]
+      },
+      {
+        'Compute': [
+          'compute/start-here',
+          'compute/scheduling-jobs',
+          'compute/checkpoint',
+          'compute/resource-monitoring',
+        ]
+      },
+            {
+        'GPUs': [
+          'gpus/gpu_start',
+          'gpus/nvidia_ngc',
+          'gpus/ollama_setup',
+        ]
+      },
+      {
+        'Data Commons': [
+          'data-commons/requirements',
+          'data-commons/imagenet',
+          'data-commons/tablib',
+          'data-commons/the_pile',
+        ]
+      },
+      {
+        'Open OnDemand': [
+          'ood/start',
+          'ood/schedule-job',
+          'ood/matlab',
+          'ood/jupyter',
+          'ood/vscode',
+          'ood/rstudio'
         ]
       }
     ],
-    'Data Commons':
-      [
-        'data-commons/requirements',
-        'data-commons/imagenet',
-        'data-commons/tablib',
-        'data-commons/the_pile',
-      ],
-    'Compute': [
-      'compute/start-here',
-      'compute/scheduling-jobs',
-      'compute/checkpoint',
-      'compute/resource-monitoring',
-    ],
-    'GPUs':[
-      'gpus/gpu_start',
-      'gpus/nvidia_ngc',
-      'gpus/ollama_setup',
+
+    'Tillicum': [
+      'tillicum/tillicum',
     ],
 
-    'Open OnDemand': [
-      'ood/start',
-      'ood/schedule-job',
-      'ood/matlab',
-      'ood/jupyter',
-      'ood/vscode',
-      'ood/rstudio'
+    'Kopah S3 Storage': [
+      'storage/kopah',
+      'storage/gui',
+      'storage/cli',
+      'storage/boto3',
+      'storage/juicefs',
     ],
+
     'Tools & Software': [
       'tools/software',
       'tools/modules',
@@ -83,6 +99,7 @@ module.exports = {
         ]
       }
     ],
+
     'Tutorials': [
       {
         'Hyak Basics': [
@@ -131,11 +148,13 @@ module.exports = {
         ]
       },
     ],
+
     'Additional Resources': [
       'resources',
       'faq',
       'glossary',
     ],
+
     'Contribution Guides': [
       'contribute/pull-request',
       'contribute/markdown-guide',


### PR DESCRIPTION
Rearrangements necessary for Tillicum user documentation to be added: 

- re working the sidebar to have a:
- Hyak Klone section
- Tillicum section
- Kopah section
- Tool & Software (shared)
- Tutorials (shared) * these will likely need to be moved since they are Klone specific. 
- etc. 

Pricing menus items redirected to KB articles on it.uw.edu

Training Videos menu added