### PR TITLE
Updated start-here.md partitions table

### DIFF
--- a/docs/compute/start-here.md
+++ b/docs/compute/start-here.md
@@ -16,28 +16,28 @@ If you are a **student** who is paying the student technology fee (STF), you are
 The account(s) you are a part of determine the priority access you have to certian partitions. 
 
 :::important 
-The table below outlines the types of compute resources available for each partition. This includes the number of slices, CPU cores, and memory per node. Use this table to determine the maximum single-node job size for each node type. For example, 40 CPUs and just under 192 GB of RAM (some RAM is dedicated to the node image) is the maximum job size for a job using a single node. Larger jobs submitted to the compute partition will be spread over multiple nodes. To ensure all 40 CPUs are requested from a single node, include the `sbatch` or `salloc` directive `--nodes=1`, otherwise Slurm will schedule your job on the first 40 CPUs available, which may be across one or more nodes. 
+The table below outlines the types of compute resources available for each partition. This includes the number of slices, CPU cores, and memory per node. Use this table to determine the maximum single-node job size for each node type. For example, 40 CPUs and just under 192 GB of RAM (some RAM is dedicated to the node image) is the maximum job size for a job using a single compute node. Larger jobs submitted to the compute partition will be spread over multiple nodes. To ensure all 40 CPUs are requested from a single node, include the `sbatch` or `salloc` directive `--nodes=1`, otherwise Slurm will schedule your job on the first 40 CPUs available, which may be across one or more nodes. 
 :::
 
 :::note Hyak Partition Overview: Slices, CPUs, and Memory Resources
 
-| Partition         | Slices per Node | CPU Cores per Node  | Memory per Node  | GPUs per Node    | Memory per GPU      |
-|------------------|------------------|---------------------|------------------|------------------|------------------|
-| compute          | 1                | 40                  | 192 GB           | 0                | -                |
-| compute-bigmem   | 1                | 40                  | 384 GB           | 0                | -                |
-| compute-hugemem  | 1                | 40                  | 750 GB           | 0                | -                |
-| compute-ultramem | 1                | 52                  | 1536 GB          | 0                | -                |
-| cpu-g2           | 6                | 192                 | 1536 GB          | 0                | -                |
-| cpu-g2-mem2x     | 6                | 192                 | 3072 GB          | 0                | -                |
-| gpu-2080ti       | 1                | 40                  | 384 GB           | 8                | 11 GB            |
-| gpu-rtx6k        | 4                | 40                  | 384 GB           | 8                | 48 GB            |
-| gpu-p100         | 2                | 56                  | 1024 GB          | 4                | 16 GB            |
-| gpu-titan        | 2                | 40                  | 384 GB           | 4                | 24 GB            |
-| gpu-a100         | 4                | 52                  | 1024 GB          | 8                | 40 GB            |
-| gpu-a40          | 4                | 52                  | 1024 GB          | 8                | 48 GB            |
-| gpu-l40          | 4                | 128                 | 1536 GB          | 8                | 48 GB            |
-| gpu-l40s         | 4                | 128                 | 1536 GB          | 8                | 48 GB            |
-| gpu-h200         | 4                | 128                 | 2304 GB          | 8                | 141 GB           |
+| Partition        | CPU Cores per Node  | Memory per Node  | GPUs per Node    | Memory per GPU      |
+|------------------|---------------------|------------------|------------------|------------------|
+| compute          | 40                  | 192 GB           | 0                | -                |
+| compute-bigmem   | 40                  | 384 GB           | 0                | -                |
+| compute-hugemem  | 40                  | 750 GB           | 0                | -                |
+| compute-ultramem | 52                  | 1536 GB          | 0                | -                |
+| cpu-g2           | 192                 | 1536 GB          | 0                | -                |
+| cpu-g2-mem2x     | 192                 | 3072 GB          | 0                | -                |
+| gpu-2080ti       | 40                  | 384 GB           | 8                | 11 GB            |
+| gpu-rtx6k        | 40                  | 384 GB           | 8                | 48 GB            |
+| gpu-p100         | 56                  | 1024 GB          | 4                | 16 GB            |
+| gpu-titan        | 40                  | 384 GB           | 4                | 24 GB            |
+| gpu-a100         | 52                  | 1024 GB          | 8                | 40 GB            |
+| gpu-a40          | 52                  | 1024 GB          | 8                | 48 GB            |
+| gpu-l40          | 128                 | 1536 GB          | 8                | 48 GB            |
+| gpu-l40s         | 128                 | 1536 GB          | 8                | 48 GB            |
+| gpu-h200         | 128                 | 2304 GB          | 8                | 141 GB           |
 
 :::
 


### PR DESCRIPTION
Updating based on @xiekc suggestions

1. In the IMPORTANT section, the sentence  "For example, 40 CPUs and just under 192 GB of RAM (some RAM is dedicated to the node image) is the maximum job size for a job using a single node.”  should be revised to
“the maximum job size for a job using a single compute node”. 
 
2. I’m not sure whether we need to include “Slices per Node” column in the table. While it’s helpful for users (especially PIs who purchased slices) to understand the full system architecture, it isn’t directly relevant to how users request resources.