### PR TITLE
Data Commons Review

### DIFF
--- a/docs/data-commons/ego4d.md
+++ b/docs/data-commons/ego4d.md
@@ -1,7 +1,12 @@
 ---
 id: ego4d
-title: Ego4d and Ego-Exo4D Dataset
+sidebar_label: Ego4d & Ego-Exo4D
+title: Ego4d & Ego-Exo4D Dataset
 ---
+
+:::warning 
+This dataset is only available on **Hyak Klone**. 
+:::
 
 Sponsoring groups are Rajesh Rao, Abhishek Gupta, Ali Farhadi. Student users are Vishwas Sathish, Chuning Zhu, and Aditya Kusupati. Initial deployment of **April 2024**.
 

--- a/docs/data-commons/epic_kitchen.md
+++ b/docs/data-commons/epic_kitchen.md
@@ -1,7 +1,12 @@
 ---
 id: kitchens
+sidebar_label: Epic Kitchens
 title: Epic Kitchens Dataset
 ---
+
+:::warning 
+This dataset is only available on **Hyak Klone**. 
+:::
 
 Sponsoring groups are Rajesh Rao, Abhishek Gupta, Ali Farhadi. Student users are Vishwas Sathish, Chuning Zhu, and Aditya Kusupati. Initial deployment of **April 2024**.
 

--- a/docs/data-commons/fineweb_edu.md
+++ b/docs/data-commons/fineweb_edu.md
@@ -1,7 +1,12 @@
 ---
 id: fineweb_edu
-title: FineWeb-Edu
+sidebar_label: FineWeb-Edu
+title: FineWeb-Edu Dataset
 ---
+
+:::tip 
+This dataset is available on **Hyak Klone and Tillicum**. 
+:::
 
 Sponsoring groups are Luke Zettlemoyer, Pang Wei Koh, and Yulia Tsvetkov. Student users are Jacqueline He, Rulin Shao, and Stella Li. Initial deployment of **June 2024**.
 
@@ -94,6 +99,8 @@ print(f"Dataset saved to {save_dir}")
 FineWeb-Edu is released under the Open Data Commons Attribution License (ODC-By) v1.0 license. The use of this dataset is also subject to CommonCrawl's Terms of Use.
 
 The file path on `klone` is `/data/fineweb_edu`.
+
+The file path on `tillicum` is `/gpfs/datasets/fineweb_edu`.
 
 ## How to cite?
 

--- a/docs/data-commons/imagenet.md
+++ b/docs/data-commons/imagenet.md
@@ -3,6 +3,10 @@ id: imagenet
 title: ImageNet
 ---
 
+:::tip 
+This dataset is available on **Hyak Klone and Tillicum**. 
+:::
+
 Sponsoring groups are Erik Lundberg, Rob Fatland, and Xiaosong Li. Student users are Nam Pho and Brenden Pelkie. Initial deployment of **October 2023**.
 
 ## What is this?
@@ -49,8 +53,8 @@ By accessing this data you agree to their terms of use provided on their website
 :::
 
 1. **PyTorch**: You can read instructions on the `ImageNet` function within PyTorch [<ins>**here**</ins>](https://pytorch.org/vision/stable/generated/torchvision.datasets.ImageNet.html). You can provide the cluster path to the function and it should present the data set for use within your Python code.
-2. **SquashFS**: The testing, training, and validation data are also provided as SquashFS objects in the base `/data/imagenet` path. You can mount this and use directly in your code. This is preferred due to the large number of small files.
-3. **Direct**: The file path on `klone` is `/data/imagenet`. It is not recommend to browse these folders directly that contain all the images due to the large number of files. This is why there are accompanyig `*_files.txt` files for each folder that contain all the file names within their respective folders for easier processing.
+2. **SquashFS**: The testing, training, and validation data are also provided as SquashFS objects in the base `/data/imagenet` path on `klone` and `/gpfs/data/imagenet` on `tillicum`. You can mount this and use directly in your code. This is preferred due to the large number of small files.
+3. **Direct**: The file path on `klone` is `/data/imagenet` and on `tillicum` is `/gpfs/data/imagenet`. It is not recommend to browse these folders directly that contain all the images due to the large number of files. This is why there are accompanyig `*_files.txt` files for each folder that contain all the file names within their respective folders for easier processing.
 
 ## How to cite?
 

--- a/docs/data-commons/kinetics.md
+++ b/docs/data-commons/kinetics.md
@@ -1,7 +1,12 @@
 ---
 id: kinetics
+sidebar_label: Kinetics
 title: Kinetics Dataset
 ---
+
+:::warning 
+This dataset is only available on **Hyak Klone**. 
+:::
 
 Sponsoring groups are Rajesh Rao, Abhishek Gupta, Ali Farhadi. Student users are Vishwas Sathish, Chuning Zhu, and Aditya Kusupati. Initial deployment of **April 2024**.
 

--- a/docs/data-commons/olmo_mix_1124.md
+++ b/docs/data-commons/olmo_mix_1124.md
@@ -1,24 +1,29 @@
 ---
 id: olmo-mix-1124
-title: olmo-mix-1124
+sidebar_label: Olmo-mix-1124
+title: olmo-mix-1124 Dataset
 ---
+
+:::warning 
+This dataset is only available on **Tillicum**. 
+:::
 
 Sponsoring groups are Noah A. Smith, Luke Zettlemoyer, and Jeffrey Heer. Student users are Rahul Nadkarni, Luiza Pozzobon, and Emily Reif. Initial deployment of **May 2025**.
 
 ## What is this?
-This is a collection of data used to train the OLMo-2-1124 language models. You can find more information on the dataset at the [Hugging Face datasets link](https://huggingface.co/datasets/allenai/olmo-mix-1124) or in the [OLMo 2 tech report](https://arxiv.org/pdf/2501.00656). The original dataset was released on November 2024 under the Open Data Commons Attribution License (ODC-By) v1.0 [license](https://opendatacommons.org/licenses/by/1-0/), and its use is also subject to [Common Crawl's Terms of Use](https://commoncrawl.org/terms-of-use).
+This is a collection of data used to train the OLMo-2-1124 language models. You can find more information on the dataset at the [<ins>**Hugging Face datasets link**</ins>](https://huggingface.co/datasets/allenai/olmo-mix-1124) or in the [<ins>**OLMo 2 tech report**</ins>](https://arxiv.org/pdf/2501.00656). The original dataset was released on November 2024 under the Open Data Commons Attribution License (ODC-By) v1.0 [<ins>**license**</ins>](https://opendatacommons.org/licenses/by/1-0/), and its use is also subject to [<ins>**Common Crawl's Terms of Use**</ins>](https://commoncrawl.org/terms-of-use).
 
 ## How to prepare for use?
-This serves as instructions for the research computing (i.e., Hyak) team to prepare this data for use on the cluster. It also serves a benefit for computational reproducibility later on.
+This serves as instructions for the research computing team to prepare this data for use on the cluster. It also serves a benefit for computational reproducibility later on.
 
-The format of this dataset is a series of memory-mapped Numpy arrays containing integer token IDs corresponding to the OLMo 2 tokenizer (e.g., [allenai/OLMo-2-1124-7B](https://huggingface.co/allenai/OLMo-2-1124-7B) on Hugging Face). The following BASH script downloads the config file for an OLMo 2 model that was trained using this data and extracts the URLs pointing to the Numpy arrays, saving the URLs to a file:
+The format of this dataset is a series of memory-mapped Numpy arrays containing integer token IDs corresponding to the OLMo 2 tokenizer (e.g., [<ins>**allenai/OLMo-2-1124-7B**</ins>](https://huggingface.co/allenai/OLMo-2-1124-7B) on Hugging Face). The following BASH script downloads the config file for an OLMo 2 model that was trained using this data and extracts the URLs pointing to the Numpy arrays, saving the URLs to a file:
 
 ```bash
 #!/bin/bash
 
 # create and change to dataset directory
-mkdir -p /data/olmo-mix-1124
-cd /data/olmo-mix-1124
+mkdir -p /gpfs/datasets/olmo-mix-1124
+cd /gpfs/datasets/olmo-mix-1124
 
 # get config file for OLMo-2-1124-7B to get URLs for data files
 wget https://raw.githubusercontent.com/allenai/OLMo/refs/heads/main/configs/official-1124/OLMo2-7B-stage1.yaml
@@ -30,13 +35,12 @@ grep "http://olmo-data.org/preprocessed" OLMo2-7B-stage1.yaml | cut -d" " -f 6 |
 rm OLMo2-7B-stage1.yaml
 ```
 
-The following Slurm script then uses the file of URLs to download the Numpy data files, using an array job to download them in parallel (to be run from the `/data/olmo-mix-1124` directory):
+The following Slurm script then uses the file of URLs to download the Numpy data files, using an array job to download them in parallel (to be run from the `/gpfs/datasets/olmo-mix-1124` directory):
 
 ```bash
 #!/bin/bash
 
 #SBATCH --partition=ckpt
-#SBATCH --account=cse
 #SBATCH --job-name=download
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
@@ -62,7 +66,7 @@ wget -O $FILEPATH $URL
 ```
 
 ## How to access?
-The path to all data files on `klone` is `/data/olmo-mix-1124`. To load the files into a single dataset, first clone the [OLMo Github repo](https://github.com/allenai/OLMo/) and follow the instructions for setting it up. Then, modify the URLs in the `data` section of the config file you wish to use (e.g., `configs/official-1124/OLMo2-7B-stage1.yaml`) to point to the files located on `klone` (this should just require replacing `http://olmo-data.org` with `/data/olmo-mix-1124`). Finally, you can load the dataset with the following Python code:
+The path to all data files on `tillicum` is `/gpfs/datasets/olmo-mix-1124`. To load the files into a single dataset, first clone the [<ins>**OLMo Github repo**</ins>](https://github.com/allenai/OLMo/) and follow the instructions for setting it up. Then, modify the URLs in the `data` section of the config file you wish to use (e.g., `configs/official-1124/OLMo2-7B-stage1.yaml`) to point to the files located on `tillicum` (this should just require replacing `http://olmo-data.org` with `/gpfs/datasets/olmo-mix-1124`). Finally, you can load the dataset with the following Python code:
 
 ```python
 from olmo.config import TrainConfig
@@ -85,7 +89,7 @@ import numpy as np
 from transformers import AutoTokenizer
 
 # load token IDs as memory-mapped Numpy array
-file_path = "/data/olmo-mix-1124/preprocessed/dclm/text_openhermes_reddit_eli5_vs_rw_v2_bigram_200k_train/allenai/dolma2-tokenizer/part-000-00000.npy"
+file_path = "/gpfs/datasets/olmo-mix-1124/preprocessed/dclm/text_openhermes_reddit_eli5_vs_rw_v2_bigram_200k_train/allenai/dolma2-tokenizer/part-000-00000.npy"
 size = os.path.getsize(file_path)
 token_ids = np.memmap(file_path, mode="r+", dtype=np.uint32, shape=(size,))
 

--- a/docs/data-commons/requirements.md
+++ b/docs/data-commons/requirements.md
@@ -3,15 +3,19 @@ id: requirements
 title: Start Here
 ---
 
-## The `klone` Data Commons
+## UW Research Computing Data Commons
 
-The `klone` Data Commons is our cluster-wide, shared dataset storage located at `/data`. The purpose of the Data Commons is to provide a single location for datasets being used by multiple groups, to avoid hosting the same dataset multiple times in separate group directories.
+Both Hyak Klone and Tillicum clusters have cluster-wide, shared dataset storage referred to as Data Commons. 
 
-Historically, we've addressed requests to add datasets to the Data Commons on a case-by-case basis. We've seen a growing number of these types of requests, so we've decided to formalize & publish our expectations.
+On `klone` the path to Data Commons is `/data/`.
+
+On `tillicum` the path to Data Commons is `/gpfs/datasets/`.
+
+The purpose of the Data Commons is to provide a central location for datasets being used by multiple groups, to avoid hosting the same dataset multiple times in separate group directories.
 
 ## Requirements
 
-In order for a dataset to be approved, the following criteria must be met:
+In order request dataset addition to Data Commons, the following criteria must be met:
 
 1. The requester must create a new page of documentation (in this folder, `/docs/data-commons`), and submit a pull request, describing the dataset:
     - A full description of the dataset, publication date, licenses, etc.
@@ -26,7 +30,7 @@ In order for a dataset to be approved, the following criteria must be met:
 
 4. Every person included in the request (again, at least 6), must indivudally attest that the dataset has been vetted: that, to the best of their knowledge, the dataset contains no material where its download/storage/use violates any State or Federal law and/or the rules/policies of UW, including intellectual property laws.
 
-:::note Documentation Contributions
+:::important Documentation Contributions
 The GitHub repository for this documentation site, with instructions for cloning & local development, is here: https://github.com/UWrc/UWrc.github.io.
 
 We have a few additional resources on documentation formatting here: https://hyak.uw.edu/docs/contribute/markdown-guide

--- a/docs/data-commons/tablib.md
+++ b/docs/data-commons/tablib.md
@@ -3,6 +3,10 @@ id: tablib
 title: TabLib
 ---
 
+:::warning 
+This dataset is only available on **Hyak Klone**. 
+:::
+
 Sponsoring groups are Ludwig Schmidt, Tim Althoff, and Pang Wei Koh. Student users are Josh Gardner, Mike Merrill, and Vinayak Gupta.
 
 # What is this?

--- a/docs/data-commons/tcga.md
+++ b/docs/data-commons/tcga.md
@@ -1,7 +1,12 @@
 ---
 id: tcga
-title: TCGA
+sidebar_label: TCGA
+title: TCGA Dataset
 ---
+
+:::warning 
+This dataset is only available on **Tillicum**. 
+:::
 
 Sponsoring groups are Su-In Lee, Linda Shapiro, Sheng Wang. Student users are Chanwoo Kim, Rustin Soraki, and Zucks Liu. Initial deployment of **March 2025**.
 
@@ -9,9 +14,9 @@ Sponsoring groups are Su-In Lee, Linda Shapiro, Sheng Wang. Student users are Ch
 <!-- ![TCGA Infographic](https://www.cancer.gov/sites/g/files/xnrzdm211/files/styles/cgov_article/public/cgov_infographic/2021-02/tcga-infographic-enlarge.png?itok=r6HLN-Ex) -->
 
 
-The Cancer Genome Atlas (TCGA) is a landmark cancer genomics program that molecularly characterized over 20,000 primary cancer samples across [33 cancer types](https://gdc.cancer.gov/resources-tcga-users/tcga-code-tables/tcga-study-abbreviations). TCGA, established in 2016 as a collaboration between the National Cancer Institute (NCI) and the National Human Genome Research Institute (NHGRI), provides a vast dataset for cancer research. The dataset encompasses [a wide range of data types](https://www.cancer.gov/ccg/research/genome-sequencing/tcga/using-tcga-data/types). It includes tissue whole slide image and multiple genomic data types, such as whole-exome sequencing, gene expression, copy number variations, and methylation data.
+The Cancer Genome Atlas (TCGA) is a landmark cancer genomics program that molecularly characterized over 20,000 primary cancer samples across [<ins>**33 cancer types**</ins>](https://gdc.cancer.gov/resources-tcga-users/tcga-code-tables/tcga-study-abbreviations). TCGA, established in 2016 as a collaboration between the National Cancer Institute (NCI) and the National Human Genome Research Institute (NHGRI), provides a vast dataset for cancer research. The dataset encompasses [<ins>**a wide range of data types**</ins>](https://www.cancer.gov/ccg/research/genome-sequencing/tcga/using-tcga-data/types). It includes tissue whole slide image and multiple genomic data types, such as whole-exome sequencing, gene expression, copy number variations, and methylation data.
 
-You can learn more at their official website [here](https://www.cancer.gov/ccg/research/genome-sequencing/tcga) or from their primary publication [here](https://www.nature.com/articles/ng.2764). 
+You can learn more at their official website [<ins>**here**</ins>](https://www.cancer.gov/ccg/research/genome-sequencing/tcga) or from their primary publication [<ins>**here**</ins>](https://www.nature.com/articles/ng.2764). 
 
 
 :::important Available Data in the Data Commons
@@ -26,19 +31,19 @@ The entire TCGA data is extremely large, totaling approximately 2.5 petabytes. C
 
 These instructions are intended to support future reproducibility and assist those who may wish to download data types beyond what is currently available in hyak data commons.
 
-TCGA organizes different cancer types as separate projects. We store data for each project as a separate folder under the main `/data/TCGA` directory.
+TCGA organizes different cancer types as separate projects. We store data for each project as a separate folder under the main `/gpfs/datasets/tgca` directory on Tillicum.
 
 Below is an example of how to set up TCGA-LUSC (Lung squamous cell carcinoma) project.
 
 ### Step 1. Download project metadata
-   1. Go to [GDC portal](https://portal.gdc.cancer.gov/analysis_page?app=Projects)
+   1. Go to [<ins>**GDC portal**</ins>](https://portal.gdc.cancer.gov/analysis_page?app=Projects)
    2. Select the project. Click on `TCGA-LUSC`
    3. Click `biospecimen–tsv` and `clinical–tsv` to download the compressed files: `clinical.project-tcga-lusc.*.tar.gz` and `biospecimen.project-tcga-lusc.*.tar.gz`
        1.  Clinical data: Includes patient metadata clinical data (e.g., `clinical.tsv`, `exposure.tsv`, `family_history.tsv`, `follow_up.tsv`, `pathology_detail.tsv`)
        2. Biospecimen Data: Contains details on available biospecimen sample (e.g., `aliquot.tsv`,  `analyte.tsv`,  `portion.tsv`, `sample.tsv`, `slide.tsv`)
-   4. Extract and store them under `/data/tcga/TCGA_LUSC/clinical` and `/data/tcga/TCGA_LUSC/biospecimen` respectively.
+   4. Extract and store them under `/gpfs/datasets/tcga/TCGA_LUSC/clinical` and `/gpfs/datasets/tcga/TCGA_LUSC/biospecimen` respectively.
    5. Finally, download the manifest file, which is a table linking each filename to its corresponding file ID. The file ID can be used to download the file via an FTP client using the URL: `https://api.gdc.cancer.gov/data/{file_id}`
-      1. Click `manifest` to download `gdc_manifest.*.txt`. Store it in `/data/tcga/TCGA_LUSC/gdc_manifest.txt`
+      1. Click `manifest` to download `gdc_manifest.*.txt`. Store it in `/gpfs/datasets/tcga/TCGA_LUSC/gdc_manifest.txt`
    
 ### Step 2. Download specific biospecimen data you are interested in. 
 Below is an example of filtering and retrieving diagnostic whole slide images:
@@ -46,14 +51,14 @@ Below is an example of filtering and retrieving diagnostic whole slide images:
 ```python
 import pandas as pd
 
-slide_df = pd.read_csv("/data/tcga/TCGA_LUSC/biospecimen/slide.tsv", sep="\t")
+slide_df = pd.read_csv("/gpfs/datasets/tcga/TCGA_LUSC/biospecimen/slide.tsv", sep="\t")
 slide_df_diagnostic = slide_df[
     slide_df["slide_submitter_id"]
     .map(lambda x: x.split("-")[-1][:2])
     .map(lambda x: {"DX": True, "BS": False, "TS": False, "MS": False}[x])
 ]
 
-manifest_df = pd.read_csv("/data/tcga/TCGA_LUSC/gdc_manifest.txt", sep="\t")
+manifest_df = pd.read_csv("/gpfs/datasets/tcga/TCGA_LUSC/gdc_manifest.txt", sep="\t")
 manifest_df["slide_submitter_id"] = manifest_df["filename"].map(
     lambda x: x.split(".")[0]
 )
@@ -68,18 +73,18 @@ data_df = slide_df_diagnostic.merge(
 url_list = data_df["id"].map(lambda x: f"https://api.gdc.cancer.gov/data/{x}").tolist()
 md5_list = data_df["md5"]
 ```
-1. Download the files iteratively and save them to `/data/tcga/TCGA_LUSC/gdc_manifest`. After downloading, we recommend verifying the MD5 checksum to ensure data integrity. 
+1. Download the files iteratively and save them to `/gpfs/datasets/tcga/TCGA_LUSC/gdc_manifest`. After downloading, we recommend verifying the MD5 checksum to ensure data integrity. 
 
 ## How to access?
 
-The data path for TCGA data on `klone` is `/data/tcga`.
+The data path for TCGA data on `tillicum` is `/gpfs/datasets/tcga`.
 
 Data from TCGA projects are organized into two tiers: Open Access and Controlled Access. We only deposit open access data in the Hyak Data Commons.
-* Open Access data tier contains data that cannot be attributed to an individual research participant. The Open Access data tier does not require user certification. Data in Open Access tier are available in the [Genomic Data Commons Data Portal](https://portal.gdc.cancer.gov/) and it can be downloaded via public FTP. 
+* Open Access data tier contains data that cannot be attributed to an individual research participant. The Open Access data tier does not require user certification. Data in Open Access tier are available in the [<ins>**Genomic Data Commons Data Portal**</ins>](https://portal.gdc.cancer.gov/) and it can be downloaded via public FTP. 
 * Controlled Access data tier contains individual-level genotype data that are unique to an individual. Access to data in the Controlled Access data tier requires user certification through dbGaP Authorized Access. 
 
-More information is available [here](https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000178.v9.p8#:~:text=Data%20from%20TCGA%20projects%20are,in%20the%20TCGA%20Data%20Portal).
+More information is available [<ins>**here**</ins>](https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000178.v9.p8#:~:text=Data%20from%20TCGA%20projects%20are,in%20the%20TCGA%20Data%20Portal).
 
 ## How to cite?
 
-Please refer to the TCGA citation guidelines [here](https://www.cancer.gov/ccg/research/genome-sequencing/tcga/using-tcga-data/citing).
+Please refer to the TCGA citation guidelines [<ins>**here**</ins>](https://www.cancer.gov/ccg/research/genome-sequencing/tcga/using-tcga-data/citing).

--- a/docs/data-commons/the_pile.md
+++ b/docs/data-commons/the_pile.md
@@ -3,6 +3,10 @@ id: the_pile
 title: The Pile
 ---
 
+:::tip 
+This dataset is available on **Hyak Klone and Tillicum**. 
+:::
+
 Sponsoring groups are Luke Zettlemoyer, Pang Wei Koh, and Hannaneh Hajishirzi. Student users are Rulin Shao, Sewon Min, and Jacqueline He. Initial deployment of **October 2023**.
 
 ## What is this?
@@ -20,6 +24,8 @@ The format of the Pile is jsonlines data compressed using zstandard.
 By accessing this data you agree to their terms of use provided on their website [<ins>**here**</ins>](https://pile.eleuther.ai/) and [<ins>**MIT License**</ins>](https://github.com/EleutherAI/the-pile/blob/master/LICENSE). 
 
 The file path on `klone` is `/data/pile`.
+
+The file path on `tillicum` is `/gpfs/datasets/pile-uncopyrighted`.
 
 ## How to cite?
 If you use the Pile or any of the components, please cite:

--- a/sidebars.js
+++ b/sidebars.js
@@ -22,13 +22,6 @@ module.exports = {
         'Storage': [
           'storage/data',
           'storage/gscratch',
-          {
-            'Data Transfer': [
-              'storage/transfer',
-              'storage/cyberduck',
-              'storage/globus',
-            ]
-          },
         ]
       },
       {
@@ -44,24 +37,6 @@ module.exports = {
           'gpus/gpu_start',
           'gpus/nvidia_ngc',
           'gpus/ollama_setup',
-        ]
-      },
-      {
-        'Data Commons': [
-          'data-commons/requirements',
-          'data-commons/imagenet',
-          'data-commons/tablib',
-          'data-commons/the_pile',
-        ]
-      },
-      {
-        'Open OnDemand': [
-          'ood/start',
-          'ood/schedule-job',
-          'ood/matlab',
-          'ood/jupyter',
-          'ood/vscode',
-          'ood/rstudio'
         ]
       }
     ],
@@ -86,7 +61,31 @@ module.exports = {
       'lolo/lolo',
       'lolo/archive'
     ],
-
+   'Data Transfer': [
+       'storage/transfer',
+       'storage/cyberduck',
+       'storage/globus',
+    ],
+    'Data Commons': [
+      'data-commons/requirements',
+      'data-commons/ego4d',
+      'data-commons/kitchens',
+      'data-commons/fineweb_edu',
+      'data-commons/imagenet',
+      'data-commons/kinetics',
+      'data-commons/olmo-mix-1124',
+      'data-commons/tablib',
+      'data-commons/tcga',
+      'data-commons/the_pile',
+    ],
+    'Open OnDemand': [
+      'ood/start',
+      'ood/schedule-job',
+      'ood/matlab',
+      'ood/jupyter',
+      'ood/vscode',
+      'ood/rstudio'
+    ],
     'Tools & Software': [
       'tools/software',
       'tools/modules',


### PR DESCRIPTION
Several changes made now that Data Commons is available for Klone and Tillicum. 

- added missing datasets to the sidebar.
- noted which datasets are available for klone, tillicum, or both. 
- added recent unfilled PRs for commons to docs and sidebar. 
- move data commons to main sidebar menu rather than within klone.
- moved data transfer and open ondemand sections to main sidebar menu since they will be for both klone and tillicum. 