### PR TITLE
Update instructions for datasets on Tillicum

### DIFF
--- a/docs/data-commons/fineweb_edu.md
+++ b/docs/data-commons/fineweb_edu.md
@@ -16,6 +16,9 @@ FineWeb-Edu is a textual dataset of 1.3T tokens from educational web pages filte
 You can learn more from [<ins>**this introductory blogpost**</ins>](https://huggingface.co/spaces/HuggingFaceFW/blogpost-fineweb-v1).
 
 ## How to prepare for use?
+
+### Klone
+
 This serves as instructions for the research computing (i.e., Hyak) team to prepare this data for use on the cluster. It also serves a benefit for computational reproducibility later on.
 
 ```
@@ -93,6 +96,12 @@ for file_url in parquet_urls:
 progress_bar.close()
 print(f"Dataset saved to {save_dir}")
 ```
+
+### Tillicum
+
+Download data from Hugging Face datasets repo [<ins>**HuggingFaceFW/fineweb-edu**</ins>](https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu).
+
+The format of the dataset is Parquet files.
 
 ## How to access?
 

--- a/docs/data-commons/imagenet.md
+++ b/docs/data-commons/imagenet.md
@@ -7,7 +7,7 @@ title: ImageNet
 This dataset is available on **Hyak Klone and Tillicum**. 
 :::
 
-Sponsoring groups are Erik Lundberg, Rob Fatland, and Xiaosong Li. Student users are Nam Pho and Brenden Pelkie. Initial deployment of **October 2023**.
+Sponsoring groups are Erik Lundberg, Rob Fatland, and Xiaosong Li. Student users are Nam Pho and Brenden Pelkie. Initial deployment of **October 2023** on Klone. Deployment of **Sep 2025** on Tillicum.
 
 ## What is this?
 
@@ -34,7 +34,7 @@ The first three images from the test set can be seen below.
 This serves as instructions for the research computing (i.e., Hyak) team to prepare this data for use on the cluster. It also serves a benefit for computational reproducibility later on.
 
 1. Register on the ImageNet website [<ins>**here**</ins>](https://www.image-net.org/challenges/LSVRC/2012/) to agree to terms of use and receive the download links.
-2. The data should arrive as a tar file. Unpack the tar file to the desired location.
+2. Alternative: Accept the rules on Kaggle [<ins>**here**</ins>](https://www.kaggle.com/competitions/imagenet-object-localization-challenge/rules) and download the dataset [<ins>**here**</ins>](https://www.kaggle.com/competitions/imagenet-object-localization-challenge/data).
 
 ## How to access?
 
@@ -52,9 +52,15 @@ By accessing this data you agree to their terms of use provided on their website
 7. The law of the State of New Jersey shall apply to all disputes under this agreement.
 :::
 
+### Klone
+
 1. **PyTorch**: You can read instructions on the `ImageNet` function within PyTorch [<ins>**here**</ins>](https://pytorch.org/vision/stable/generated/torchvision.datasets.ImageNet.html). You can provide the cluster path to the function and it should present the data set for use within your Python code.
 2. **SquashFS**: The testing, training, and validation data are also provided as SquashFS objects in the base `/data/imagenet` path on `klone` and `/gpfs/data/imagenet` on `tillicum`. You can mount this and use directly in your code. This is preferred due to the large number of small files.
 3. **Direct**: The file path on `klone` is `/data/imagenet` and on `tillicum` is `/gpfs/data/imagenet`. It is not recommend to browse these folders directly that contain all the images due to the large number of files. This is why there are accompanyig `*_files.txt` files for each folder that contain all the file names within their respective folders for easier processing.
+
+### Tillicum
+
+Please see the instructions for the [<ins>**ImageNet Object Localization Challenge**</ins>](https://www.kaggle.com/competitions/imagenet-object-localization-challenge/overview).
 
 ## How to cite?
 

--- a/docs/data-commons/olmo_mix_1124.md
+++ b/docs/data-commons/olmo_mix_1124.md
@@ -16,87 +16,12 @@ This is a collection of data used to train the OLMo-2-1124 language models. You 
 ## How to prepare for use?
 This serves as instructions for the research computing team to prepare this data for use on the cluster. It also serves a benefit for computational reproducibility later on.
 
-The format of this dataset is a series of memory-mapped Numpy arrays containing integer token IDs corresponding to the OLMo 2 tokenizer (e.g., [<ins>**allenai/OLMo-2-1124-7B**</ins>](https://huggingface.co/allenai/OLMo-2-1124-7B) on Hugging Face). The following BASH script downloads the config file for an OLMo 2 model that was trained using this data and extracts the URLs pointing to the Numpy arrays, saving the URLs to a file:
+Download data from Hugging Face datasets repo [<ins>**allenai/olmo-mix-1124**</ins>](https://huggingface.co/datasets/allenai/olmo-mix-1124).
 
-```bash
-#!/bin/bash
-
-# create and change to dataset directory
-mkdir -p /gpfs/datasets/olmo-mix-1124
-cd /gpfs/datasets/olmo-mix-1124
-
-# get config file for OLMo-2-1124-7B to get URLs for data files
-wget https://raw.githubusercontent.com/allenai/OLMo/refs/heads/main/configs/official-1124/OLMo2-7B-stage1.yaml
-
-# get URLs of .npy files, write to new file
-grep "http://olmo-data.org/preprocessed" OLMo2-7B-stage1.yaml | cut -d" " -f 6 | sort | uniq > urls.txt
-
-# remove config file
-rm OLMo2-7B-stage1.yaml
-```
-
-The following Slurm script then uses the file of URLs to download the Numpy data files, using an array job to download them in parallel (to be run from the `/gpfs/datasets/olmo-mix-1124` directory):
-
-```bash
-#!/bin/bash
-
-#SBATCH --partition=ckpt
-#SBATCH --job-name=download
-#SBATCH --nodes=1
-#SBATCH --ntasks=1
-#SBATCH --cpus-per-task=2
-#SBATCH --mem-per-cpu=100M
-#SBATCH --time=5:00:00
-#SBATCH --array=1-1117
-#SBATCH --output=slurm/download-%A-%a.log
-#SBATCH --error=slurm/download-%A-%a.log
-#SBATCH --export=all
-
-# get URL from URLs file
-URL=$(sed -n ${SLURM_ARRAY_TASK_ID}p urls.txt)
-
-# get file path from URL
-FILEPATH=$(echo $URL | cut -d"/" -f 4-)
-
-# create nested directory for file
-mkdir -p $(dirname $FILEPATH)
-
-# download file into directory
-wget -O $FILEPATH $URL
-```
+The format of the dataset is json files compressed using gzip.
 
 ## How to access?
-The path to all data files on `tillicum` is `/gpfs/datasets/olmo-mix-1124`. To load the files into a single dataset, first clone the [<ins>**OLMo Github repo**</ins>](https://github.com/allenai/OLMo/) and follow the instructions for setting it up. Then, modify the URLs in the `data` section of the config file you wish to use (e.g., `configs/official-1124/OLMo2-7B-stage1.yaml`) to point to the files located on `tillicum` (this should just require replacing `http://olmo-data.org` with `/gpfs/datasets/olmo-mix-1124`). Finally, you can load the dataset with the following Python code:
-
-```python
-from olmo.config import TrainConfig
-from olmo.data import build_memmap_dataset
-
-# replace with path to config file you want to use
-train_config_path = "configs/official-1124/OLMo2-7B-stage1.yaml"
-
-cfg = TrainConfig.load(train_config_path)
-dataset = build_memmap_dataset(cfg, cfg.data)
-```
-
-Note that this does not construct the dataset such that the data batches are in the same order as was used to train the OLMo-2-1124 models. For more details on that, refer to the training code in the OLMo Github repo.
-
-The following snippet of code shows how to load each file individually and convert from the token IDs to the original raw text using a Hugging Face tokenizer:
-
-```python
-import os
-import numpy as np
-from transformers import AutoTokenizer
-
-# load token IDs as memory-mapped Numpy array
-file_path = "/gpfs/datasets/olmo-mix-1124/preprocessed/dclm/text_openhermes_reddit_eli5_vs_rw_v2_bigram_200k_train/allenai/dolma2-tokenizer/part-000-00000.npy"
-size = os.path.getsize(file_path)
-token_ids = np.memmap(file_path, mode="r+", dtype=np.uint32, shape=(size,))
-
-# decode token IDs into text
-tokenizer = AutoTokenizer.from_pretrained("allenai/OLMo-2-1124-7B")
-text = tokenizer.decode(token_ids)
-```
+The path to all data files on `tillicum` is `/gpfs/datasets/olmo-mix-1124`. 
 
 ## How to cite?
 If you use this dataset or any of the components, please cite:

--- a/docs/data-commons/the_pile.md
+++ b/docs/data-commons/the_pile.md
@@ -7,10 +7,12 @@ title: The Pile
 This dataset is available on **Hyak Klone and Tillicum**. 
 :::
 
-Sponsoring groups are Luke Zettlemoyer, Pang Wei Koh, and Hannaneh Hajishirzi. Student users are Rulin Shao, Sewon Min, and Jacqueline He. Initial deployment of **October 2023**.
+Sponsoring groups are Luke Zettlemoyer, Pang Wei Koh, and Hannaneh Hajishirzi. Student users are Rulin Shao, Sewon Min, and Jacqueline He. Initial deployment of **October 2023** on Klone. The Pile **uncopyrighted version** depoyed in **Sep 2025** on Tillicum.
 
 ## What is this?
-The Pile is a 825 GiB diverse, open source language modelling data set that consists of 22 smaller, high-quality datasets combined together.
+The Pile is a 825 GiB diverse, open source language modelling data set that consists of 22 smaller, high-quality datasets combined together. 
+
+A copy of The Pile with all copyrighted content removed is held on Tillicum.
 
 You can learn more at their website [<ins>**here**</ins>](https://pile.eleuther.ai/) or from their paper [<ins>**here**</ins>](https://arxiv.org/abs/2101.00027).
 


### PR DESCRIPTION
Update instructions for datasets on Tillicum, including fineweb-edu, imagenet, olmo_mix_1124, and the pile.