### PR TITLE
Add epic-kitchens, kinetics, and tablib datasets to Tillicum

### DIFF
--- a/docs/data-commons/epic_kitchen.md
+++ b/docs/data-commons/epic_kitchen.md
@@ -4,8 +4,8 @@ sidebar_label: Epic Kitchens
 title: Epic Kitchens Dataset
 ---
 
-:::warning 
-This dataset is only available on **Hyak Klone**. 
+:::tip 
+This dataset is available on **Hyak Klone and Tillicum**. 
 :::
 
 Sponsoring groups are Rajesh Rao, Abhishek Gupta, Ali Farhadi. Student users are Vishwas Sathish, Chuning Zhu, and Aditya Kusupati. Initial deployment of **April 2024**.
@@ -30,7 +30,10 @@ vr = VideoReader(file_path, num_threads=-1, ctx=cpu(0))
 ## How to access?
 
 The epic kitchens dataset and benchmarks on this page are copyright by us and published under the [<ins>**Creative Commons Attribution-NonCommercial 4.0 International License**</ins>](https://creativecommons.org/licenses/by-nc/4.0/).
-The file path for kitchens dataset on `klone` is `/data/epic_kitchens`.
+
+The file path for epic kitchens dataset on `klone` is `/data/epic_kitchens`.
+
+The file path for epic kitchens dataset on `tillicum` is `/gpfs/datasets/epic_kitchens`.
 
 ## How to cite?
 If you use the Epic Kitchens dataset or any of the components, please cite the following papers:

--- a/docs/data-commons/fineweb_edu.md
+++ b/docs/data-commons/fineweb_edu.md
@@ -8,7 +8,7 @@ title: FineWeb-Edu Dataset
 This dataset is available on **Hyak Klone and Tillicum**. 
 :::
 
-Sponsoring groups are Luke Zettlemoyer, Pang Wei Koh, and Yulia Tsvetkov. Student users are Jacqueline He, Rulin Shao, and Stella Li. Initial deployment of **June 2024**.
+Sponsoring groups are Luke Zettlemoyer, Pang Wei Koh, and Yulia Tsvetkov. Student users are Jacqueline He, Rulin Shao, and Stella Li. Initial deployment of **June 2024** on Klone and **Sep 2025** on Tillicum.
 
 ## What is this?
 FineWeb-Edu is a textual dataset of 1.3T tokens from educational web pages filtered from FineWeb (a 15T token dataset derived from 96 CommonCrawl snapshots). 

--- a/docs/data-commons/imagenet.md
+++ b/docs/data-commons/imagenet.md
@@ -7,7 +7,7 @@ title: ImageNet
 This dataset is available on **Hyak Klone and Tillicum**. 
 :::
 
-Sponsoring groups are Erik Lundberg, Rob Fatland, and Xiaosong Li. Student users are Nam Pho and Brenden Pelkie. Initial deployment of **October 2023** on Klone. Deployment of **Sep 2025** on Tillicum.
+Sponsoring groups are Erik Lundberg, Rob Fatland, and Xiaosong Li. Student users are Nam Pho and Brenden Pelkie. Initial deployment of **October 2023** on Klone and **Sep 2025** on Tillicum.
 
 ## What is this?
 
@@ -55,8 +55,8 @@ By accessing this data you agree to their terms of use provided on their website
 ### Klone
 
 1. **PyTorch**: You can read instructions on the `ImageNet` function within PyTorch [<ins>**here**</ins>](https://pytorch.org/vision/stable/generated/torchvision.datasets.ImageNet.html). You can provide the cluster path to the function and it should present the data set for use within your Python code.
-2. **SquashFS**: The testing, training, and validation data are also provided as SquashFS objects in the base `/data/imagenet` path on `klone` and `/gpfs/data/imagenet` on `tillicum`. You can mount this and use directly in your code. This is preferred due to the large number of small files.
-3. **Direct**: The file path on `klone` is `/data/imagenet` and on `tillicum` is `/gpfs/data/imagenet`. It is not recommend to browse these folders directly that contain all the images due to the large number of files. This is why there are accompanyig `*_files.txt` files for each folder that contain all the file names within their respective folders for easier processing.
+2. **SquashFS**: The testing, training, and validation data are also provided as SquashFS objects in the base `/data/imagenet` path on `klone` and `/gpfs/datasets/imagenet` on `tillicum`. You can mount this and use directly in your code. This is preferred due to the large number of small files.
+3. **Direct**: The file path on `klone` is `/data/imagenet` and on `tillicum` is `/gpfs/datasets/imagenet`. It is not recommend to browse these folders directly that contain all the images due to the large number of files. This is why there are accompanyig `*_files.txt` files for each folder that contain all the file names within their respective folders for easier processing.
 
 ### Tillicum
 

--- a/docs/data-commons/kinetics.md
+++ b/docs/data-commons/kinetics.md
@@ -4,11 +4,11 @@ sidebar_label: Kinetics
 title: Kinetics Dataset
 ---
 
-:::warning 
-This dataset is only available on **Hyak Klone**. 
+:::tip 
+This dataset is available on **Hyak Klone and Tillicum**. 
 :::
 
-Sponsoring groups are Rajesh Rao, Abhishek Gupta, Ali Farhadi. Student users are Vishwas Sathish, Chuning Zhu, and Aditya Kusupati. Initial deployment of **April 2024**.
+Sponsoring groups are Rajesh Rao, Abhishek Gupta, Ali Farhadi. Student users are Vishwas Sathish, Chuning Zhu, and Aditya Kusupati. Initial deployment of **April 2024** on Klone and **Sep 2025** on Tillicum.
 
 ## What is this?
 Kinetics is a collection of large-scale, high-quality datasets of URL links of up to 650,000 video clips that cover 400/600/700 human action classes, depending on the dataset version. 
@@ -31,6 +31,8 @@ vr = VideoReader(file_path, num_threads=-1, ctx=cpu(0))
 ## How to access?
 
 The file path for kinetics dataset on `klone` is `/data/kinetics`.
+
+The file path for kinetics dataset on `tillicum` is `/gpfs/datasets/kinetics`.
 
 The kinetics dataset is licensed by Google Inc. under a Creative Commons Attribution 4.0 International License. Published. May 22, 2017.
 

--- a/docs/data-commons/olmo_mix_1124.md
+++ b/docs/data-commons/olmo_mix_1124.md
@@ -8,7 +8,7 @@ title: olmo-mix-1124 Dataset
 This dataset is only available on **Tillicum**. 
 :::
 
-Sponsoring groups are Noah A. Smith, Luke Zettlemoyer, and Jeffrey Heer. Student users are Rahul Nadkarni, Luiza Pozzobon, and Emily Reif. Initial deployment of **May 2025**.
+Sponsoring groups are Noah A. Smith, Luke Zettlemoyer, and Jeffrey Heer. Student users are Rahul Nadkarni, Luiza Pozzobon, and Emily Reif. Initial deployment of **Sep 2025**.
 
 ## What is this?
 This is a collection of data used to train the OLMo-2-1124 language models. You can find more information on the dataset at the [<ins>**Hugging Face datasets link**</ins>](https://huggingface.co/datasets/allenai/olmo-mix-1124) or in the [<ins>**OLMo 2 tech report**</ins>](https://arxiv.org/pdf/2501.00656). The original dataset was released on November 2024 under the Open Data Commons Attribution License (ODC-By) v1.0 [<ins>**license**</ins>](https://opendatacommons.org/licenses/by/1-0/), and its use is also subject to [<ins>**Common Crawl's Terms of Use**</ins>](https://commoncrawl.org/terms-of-use).

--- a/docs/data-commons/tablib.md
+++ b/docs/data-commons/tablib.md
@@ -3,11 +3,11 @@ id: tablib
 title: TabLib
 ---
 
-:::warning 
-This dataset is only available on **Hyak Klone**. 
+:::tip 
+This dataset is available on **Hyak Klone and Tillicum**. 
 :::
 
-Sponsoring groups are Ludwig Schmidt, Tim Althoff, and Pang Wei Koh. Student users are Josh Gardner, Mike Merrill, and Vinayak Gupta.
+Sponsoring groups are Ludwig Schmidt, Tim Althoff, and Pang Wei Koh. Student users are Josh Gardner, Mike Merrill, and Vinayak Gupta. Initial deployment of **Sep 2025** on Tillicum.
 
 # What is this?
 
@@ -38,6 +38,10 @@ tables = [pa.RecordBatchStreamReader(b).read_all() for b in df['arrow_bytes']]
 
 ```
 # How to access?
+
+The file path for TablLib dataset on `klone` is `/data/tablib`.
+
+The file path for TablLib dataset on `tillicum` is `/gpfs/datasets/tablib`.
 
 Users who access the data should also apply for public, open credentialized access to the dataset on Hugging Face Datasets [<ins>**here**</ins>](https://huggingface.co/datasets/approximatelabs/tablib-v1-full).
 

--- a/docs/data-commons/tcga.md
+++ b/docs/data-commons/tcga.md
@@ -8,7 +8,7 @@ title: TCGA Dataset
 This dataset is only available on **Tillicum**. 
 :::
 
-Sponsoring groups are Su-In Lee, Linda Shapiro, Sheng Wang. Student users are Chanwoo Kim, Rustin Soraki, and Zucks Liu. Initial deployment of **March 2025**.
+Sponsoring groups are Su-In Lee, Linda Shapiro, Sheng Wang. Student users are Chanwoo Kim, Rustin Soraki, and Zucks Liu. Initial deployment of **Sep 2025**.
 
 ## What is this?
 <!-- ![TCGA Infographic](https://www.cancer.gov/sites/g/files/xnrzdm211/files/styles/cgov_article/public/cgov_infographic/2021-02/tcga-infographic-enlarge.png?itok=r6HLN-Ex) -->

--- a/docs/data-commons/the_pile.md
+++ b/docs/data-commons/the_pile.md
@@ -7,7 +7,7 @@ title: The Pile
 This dataset is available on **Hyak Klone and Tillicum**. 
 :::
 
-Sponsoring groups are Luke Zettlemoyer, Pang Wei Koh, and Hannaneh Hajishirzi. Student users are Rulin Shao, Sewon Min, and Jacqueline He. Initial deployment of **October 2023** on Klone. The Pile **uncopyrighted version** depoyed in **Sep 2025** on Tillicum.
+Sponsoring groups are Luke Zettlemoyer, Pang Wei Koh, and Hannaneh Hajishirzi. Student users are Rulin Shao, Sewon Min, and Jacqueline He. Initial deployment of **October 2023** on Klone. The Pile **uncopyrighted version** deployed in **Sep 2025** on Tillicum.
 
 ## What is this?
 The Pile is a 825 GiB diverse, open source language modelling data set that consists of 22 smaller, high-quality datasets combined together. 


### PR DESCRIPTION
Add Epic-Kitchens, Kinetics, and TabLib datasets to Tillicum; Correct some typos in Data Commons section.