### PR TITLE
Accessibility: Updated link/code colors for dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -17,6 +17,17 @@
   --ifm-code-font-size: 95%;
 }
 
+[data-theme='dark'] {
+  --ifm-color-primary: #c5b4e3;
+  --ifm-color-primary-dark: #b49dd9;
+  --ifm-color-primary-darker: #ab92d5;
+  --ifm-color-primary-darkest: #8b6bc5;
+  --ifm-color-primary-light: #d6cbed;
+  --ifm-color-primary-lighter: #dfd6f0;
+  --ifm-color-primary-lightest: #f0ecf7;
+  --ifm-link-color: #c5b4e3;
+}
+
 
 /* bootstrap override */
 .navbar__title {
@@ -46,7 +57,19 @@
 }
 
 code {
-  color: #39275B
+  color: #39275B;
+}
+
+html[data-theme='dark'] a {
+  color: #c5b4e3;
+}
+
+html[data-theme='dark'] a:hover {
+  color: #d9ccf0;
+}
+
+html[data-theme='dark'] :not(pre) > code {
+  color: #aadb1e;
 }
 
 ul.check li {


### PR DESCRIPTION
List of changes:
1. Added a `[data-theme='dark']` block with the primary color set to #c5b4e3. Docusaurus/Infima derives link colors from `--ifm-color-primary`, so setting it in the dark theme selector ensures links use the lighter purple throughout.

2. Added `html[data-theme='dark']` a with color: #c5b4e3 as a direct override for all links in dark mode.

3. Added `html[data-theme='dark'] :not(pre) > code` with color: #aadb1e — this targets only inline `<code>` elements (not ones inside` <pre>`, which are code blocks). 

Example image: 
<img width="2940" height="1434" alt="image" src="https://github.com/user-attachments/assets/66b4c5a5-a3dc-4f3b-ad20-933297aa8ef9" />